### PR TITLE
add a link to the scan page

### DIFF
--- a/_includes/glossary-scan.md
+++ b/_includes/glossary-scan.md
@@ -1,1 +1,1 @@
-A Soda SQL CLI command that executes tests to extract information about data in a data source.
+A Soda SQL CLI command that executes tests to extract information about data in a data source. Check the [Run a scan](https://docs.soda.io/soda/scan.html#run-a-scan) page for more information.

--- a/_includes/glossary-scan.md
+++ b/_includes/glossary-scan.md
@@ -1,1 +1,1 @@
-A Soda SQL CLI command that executes tests to extract information about data in a data source. Check the [Run a scan](https://docs.soda.io/soda/scan.html#run-a-scan) page for more information.
+A Soda SQL CLI command that executes tests to extract information about data in a data source. Check the [Run a scan]({% link soda/scan.md %}#run-a-scan) page for more information.


### PR DESCRIPTION
I realised that while most entried in the glossary point to a helpful "read-more" kind of link in our docs, it wasn't the case for "scan". So here is one. Feel free to let me know if you would like me to change the CTA or point to a different page.

**NOTE:** I'm not too sure if I've done the right thing when it comes to the link gen but I think I did?