### PR TITLE
Back to 500 for the site-button since antialiasing is turned off.

### DIFF
--- a/_sass/color_schemes/soda.scss
+++ b/_sass/color_schemes/soda.scss
@@ -297,7 +297,7 @@ $code-background-color: #f8f9f9;
         background-color: #00D891;
         font-size: 15px;
         line-height: 20px;
-        font-weight: 600;
+        font-weight: 500;
         color: #fff;
         transition: background-color .4s ease-out;
 


### PR DESCRIPTION
Forgot the huge effect antialiasing has on font-weight now that it is back to being turned off.  Now that Dahlia has a chance to review, sticking to 500 everywhere assuming antialiasing is turned off.