### PR TITLE
scroll-margin-top to offset for the header (fixes issue where anchors scroll beyond the header)

### DIFF
--- a/_sass/color_schemes/soda.scss
+++ b/_sass/color_schemes/soda.scss
@@ -461,6 +461,12 @@ h5,
 h6 {
     font-weight: 600 !important;
     color: #000000 !important;
+
+    scroll-margin-top: 60px;
+    
+    @media (min-width: 50rem) {
+        scroll-margin-top: 80px;
+    }
 }
 
 .main-content h1 {


### PR DESCRIPTION
All headers (h1, h2, etc.) need an offset for scrolling due to fixed header definition. 