### PR TITLE
Add cloud metric names

### DIFF
--- a/_includes/column-metrics.md
+++ b/_includes/column-metrics.md
@@ -2,29 +2,29 @@
 | ----------------------- | ----------- | --------------------- | ----------------------------- | ----------------------------- |
 | `avg`| Average | The calculated average of the values in a numeric column. | number |  - | 
 | `avg_length` | Average Length | The average length of string values in a column.  | text  |  -  |
-| `distinct`<sup>1</sup> | Distinct Values | The number of rows that contain distinct values, relative to the column. |   | - | 
-| `duplicate_count`<sup>1</sup>| Duplicate Values | The number of rows that contain duplicate values, relative to the column. |  | - |
-| `frequent_values`<sup>1</sup> | Top Values | A list of values in the column and the frequency with which they occur. |  | - |
-| `histogram`<sup>1</sup> | Histogram | A list of values to use to create a histogram that represents the contents of the column. |  | - |
-| `invalid_count` | Invalid Values | The number of rows that contain invalid values. | text  | `valid_format` <br /> `valid_regex` <br /> `valid_values` <br /> `valid_min_length` <br /> `valid_max_length`|
-| `invalid_percentage` | Invalid Values (%) |The percentage of rows that contain invalid values.  | text  |  `valid_format` <br /> `valid_regex` <br />`valid_values`<br /> `valid_min_length` <br /> `valid_max_length` |
-| `max` | Maximum Value | The greatest value in a numeric column. |  number  |  -  |
+| `distinct`<sup>1</sup> | Distinct Values | The number of rows that contain distinct values, relative to the column. | number | - | 
+| `duplicate_count`<sup>1</sup>| Duplicate Values | The number of rows that contain duplicate values, relative to the column. | text, number, time  | - |
+| `frequent_values`<sup>1</sup> | Top Values | A list of values in the column and the frequency with which they occur. | text, number, time  | - |
+| `histogram`<sup>1</sup> | Histogram | A list of values to use to create a histogram that represents the contents of the column. | number | - |
+| `invalid_count` | Invalid Values | The number of rows that contain invalid values. | text, number, time  | `valid_format` <br /> `valid_regex` <br /> `valid_values` <br /> `valid_min_length` <br /> `valid_max_length`|
+| `invalid_percentage` | Invalid Values (%) |The percentage of rows that contain invalid values.  | text, number, time  |  `valid_format` <br /> `valid_regex` <br />`valid_values`<br /> `valid_min_length` <br /> `valid_max_length` |
+| `max` | Maximum Value | The greatest value in a numeric column. |  number, time  |  -  |
 | `max_length` | Maximum Length | The maximum length of string values in a column. |  text  |  -  |
-| `maxs`<sup>1</sup> | Maxs | A list of values that qualify as maximum relative to other values in the column. | number | - |
-| `min` | Minimum Value | The smallest value in a numeric column.  | number |  -  |
+| `maxs`<sup>1</sup> | Maxs | A list of values that qualify as maximum relative to other values in the column. | text, number, time | - |
+| `min` | Minimum Value | The smallest value in a numeric column.  | number, time |  -  |
 | `min_length` | Minimum Length | The minimum length of string values in a column.  | text  |  -  |
-| `mins`<sup>1</sup> | Mins | A list of values that qualify as minimum relative to other values in the column. | number | - |
-| `missing_count` | Missing Values | The number of rows in a column that do not contain specific content. | text, number, date  | `missing_format` <br /> `missing_regex` <br /> `missing_values`  |
-| `missing_percentage` | Missing Values (%) | The percentage of rows in a column that do not contain specific content. | text, number, date  | `missing_format` <br /> `missing_regex` <br /> `missing_values`|
-| `row_count` | n/a | The number of rows in a column. |  text, number, date | - |
+| `mins`<sup>1</sup> | Mins | A list of values that qualify as minimum relative to other values in the column. | text, number, time | - |
+| `missing_count` | Missing Values | The number of rows in a column that do not contain specific content. | text, number, time  | `missing_format` <br /> `missing_regex` <br /> `missing_values`  |
+| `missing_percentage` | Missing Values (%) | The percentage of rows in a column that do not contain specific content. | text, number, time  | `missing_format` <br /> `missing_regex` <br /> `missing_values`|
+| `row_count` | n/a | The number of rows in a column. |  text, number, time | - |
 | `stddev` | Standard Deviation | The calculated standard deviation of values in a numeric column. | number | - |
 | `sum` | Sum | The calculated sum of the values in a numeric column.   | number | -  |
-| `unique_count`<sup>1</sup> | Unique Values | The number of rows in which a value appears exactly only once in the column. |  | - |
-| `uniqueness`<sup>1</sup> | Uniqueness (%) | A ratio that produces a number between 0 and 100 that indicates how unique the data in a column is. 0 indicates that all the values are the same; 100 indicates that all the values in the column are unique. |  | - |
-| `valid_count` |  Valid Values | The number of rows that contain valid content.  | text  | `valid_format` <br /> `valid_regex` <br /> `valid_values` <br /> `valid_min_length` <br /> `valid_max_length` |
-| `valid_percentage` | n/a | The percentage of rows that contain valid content.  |  text |  `valid_format` <br /> `valid_regex` <br /> `valid_values` <br /> `valid_min_length` <br /> `valid_max_length` |
-| `values_count` | Values | The number of rows that contain content included in a list of valid values. |  text | `valid_values` <br /> `valid_regex` |
-| `values_percentage` | Values (%) | The percentage of rows that contain content identified by valid values. | text | `valid_values` <br /> `valid_regex` |
-| `variance` | Variance | The calculated variance of the values in a numeric column.  | number  | - |
+| `unique_count`<sup>1</sup> | Unique Values | The number of rows in which a value appears exactly only once in the column. | text, number, time | - |
+| `uniqueness`<sup>1</sup> | Uniqueness (%) | A ratio that produces a number between 0 and 100 that indicates how unique the data in a column is. 0 indicates that all the values are the same; 100 indicates that all the values in the column are unique. | text, number, time | - |
+| `valid_count` |  Valid Values | The number of rows that contain valid content.  | text, number, time  | `valid_format` <br /> `valid_regex` <br /> `valid_values` <br /> `valid_min_length` <br /> `valid_max_length` |
+| `valid_percentage` | n/a | The percentage of rows that contain valid content.  |  text, number, time |  `valid_format` <br /> `valid_regex` <br /> `valid_values` <br /> `valid_min_length` <br /> `valid_max_length` |
+| `values_count` | Values | The number of rows that contain content included in a list of valid values. |  text, number, time | `valid_values` <br /> `valid_regex` |
+| `values_percentage` | Values (%) | The percentage of rows that contain content identified by valid values. | text, number, time | `valid_values` <br /> `valid_regex` |
+| `variance` | Variance | The calculated variance of the values in a numeric column.  | number, time  | - |
 
 <sup>1</sup> When configuring these metrics in Soda SQL, you must also define a [metric group]({% link soda-sql/sql_metrics.md %}#metric-groups-and-dependencies) in the scan YAML file.

--- a/_includes/column-metrics.md
+++ b/_includes/column-metrics.md
@@ -1,20 +1,30 @@
-| Column metric   | Description |  Applies to [data type]({% link soda/supported-data-types.md %}) | Column config key(s) / Validity Rule(s) | 
-| ----------------------- | ----------- | --------------------- | ----------------------------- |
-| `avg` | The calculated average of the values in a numeric column. | number |  - | 
-| `avg_length` | The average length of string values in a column.  | text  |  -  |
-| `invalid_count` | The number of rows that contain invalid values. | text  | `valid_format` <br /> `valid_regex` <br /> `valid_values` <br /> `valid_min_length` <br /> `valid_max_length`|
-| `invalid_percentage` | The percentage of rows that contain invalid values.  | text  |  `valid_format` <br /> `valid_regex` <br />`valid_values`<br /> `valid_min_length` <br /> `valid_max_length` |
-| `max` | The greatest value in a numeric column. |  number  |  -  |
-| `max_length` | The maximum length of string values in a column. |  text  |  -  |
-| `min` | The smallest value in a numeric column.  | number |  -  |
-| `min_length` | The minimum length of string values in a column.  | text  |  -  |
-| `missing_count` | The number of rows in a column that do not contain specific content. | text, number, date  | `missing_format` <br /> `missing_regex` <br /> `missing_values`  |
-| `missing_percentage` | The percentage of rows in a column that do not contain specific content. | text, number, date  | `missing_format` <br /> `missing_regex` <br /> `missing_values`|
-| `row_count` | The number of rows in a column. |  text, number, date | - |
-| `stddev` |  The calculated standard deviation of values in a numeric column. | number | - |
-| `sum` | The calculated sum of the values in a numeric column.   | number | -  |
-| `valid_count` |  The number of rows that contain valid content.  | text  | `valid_format` <br /> `valid_regex` <br /> `valid_values` <br /> `valid_min_length` <br /> `valid_max_length` |
-| `valid_percentage` | The percentage of rows that contain valid content.  |  text |  `valid_format` <br /> `valid_regex` <br /> `valid_values` <br /> `valid_min_length` <br /> `valid_max_length` |
-| `values_count` | The number of rows that contain content included in a list of valid values. |  text | `valid_values` <br /> `valid_regex` |
-| `values_percentage` | The percentage of rows that contain content identified by valid values. | text | `valid_values` <br /> `valid_regex` |
-| `variance` | The calculated variance of the values in a numeric column.  | number  | - |
+| Column metric<br /> in Soda SQL | Column metric<br /> in Soda Cloud |Description |  Applies to [data type]({% link soda/supported-data-types.md %}) | Column config key(s) / Validity Rule(s) | 
+| ----------------------- | ----------- | --------------------- | ----------------------------- | ----------------------------- |
+| `avg`| Average | The calculated average of the values in a numeric column. | number |  - | 
+| `avg_length` | Average Length | The average length of string values in a column.  | text  |  -  |
+| `distinct`<sup>1</sup> | Distinct Values | The number of rows that contain distinct values, relative to the column. |   | - | 
+| `duplicate_count`<sup>1</sup>| Duplicate Values | The number of rows that contain duplicate values, relative to the column. |  | - |
+| `frequent_values`<sup>1</sup> | Top Values | A list of values in the column and the frequency with which they occur. |  | - |
+| `histogram`<sup>1</sup> | Histogram | A list of values to use to create a histogram that represents the contents of the column. |  | - |
+| `invalid_count` | Invalid Values | The number of rows that contain invalid values. | text  | `valid_format` <br /> `valid_regex` <br /> `valid_values` <br /> `valid_min_length` <br /> `valid_max_length`|
+| `invalid_percentage` | Invalid Values (%) |The percentage of rows that contain invalid values.  | text  |  `valid_format` <br /> `valid_regex` <br />`valid_values`<br /> `valid_min_length` <br /> `valid_max_length` |
+| `max` | Maximum Value | The greatest value in a numeric column. |  number  |  -  |
+| `max_length` | Maximum Length | The maximum length of string values in a column. |  text  |  -  |
+| `maxs`<sup>1</sup> | Maxs | A list of values that qualify as maximum relative to other values in the column. | number | - |
+| `min` | Minimum Value | The smallest value in a numeric column.  | number |  -  |
+| `min_length` | Minimum Length | The minimum length of string values in a column.  | text  |  -  |
+| `mins`<sup>1</sup> | Mins | A list of values that qualify as minimum relative to other values in the column. | number | - |
+| `missing_count` | Missing Values | The number of rows in a column that do not contain specific content. | text, number, date  | `missing_format` <br /> `missing_regex` <br /> `missing_values`  |
+| `missing_percentage` | Missing Values (%) | The percentage of rows in a column that do not contain specific content. | text, number, date  | `missing_format` <br /> `missing_regex` <br /> `missing_values`|
+| `row_count` | n/a | The number of rows in a column. |  text, number, date | - |
+| `stddev` | Standard Deviation | The calculated standard deviation of values in a numeric column. | number | - |
+| `sum` | Sum | The calculated sum of the values in a numeric column.   | number | -  |
+| `unique_count`<sup>1</sup> | Unique Values | The number of rows in which a value appears exactly only once in the column. |  | - |
+| `uniqueness`<sup>1</sup> | Uniqueness (%) | A ratio that produces a number between 0 and 100 that indicates how unique the data in a column is. 0 indicates that all the values are the same; 100 indicates that all the values in the column are unique. |  | - |
+| `valid_count` |  Valid Values | The number of rows that contain valid content.  | text  | `valid_format` <br /> `valid_regex` <br /> `valid_values` <br /> `valid_min_length` <br /> `valid_max_length` |
+| `valid_percentage` | n/a | The percentage of rows that contain valid content.  |  text |  `valid_format` <br /> `valid_regex` <br /> `valid_values` <br /> `valid_min_length` <br /> `valid_max_length` |
+| `values_count` | Values | The number of rows that contain content included in a list of valid values. |  text | `valid_values` <br /> `valid_regex` |
+| `values_percentage` | Values (%) | The percentage of rows that contain content identified by valid values. | text | `valid_values` <br /> `valid_regex` |
+| `variance` | Variance | The calculated variance of the values in a numeric column.  | number  | - |
+
+<sup>1</sup> When configuring these metrics in Soda SQL, you must also define a [metric group]({% link soda-sql/sql_metrics.md %}#metric-groups-and-dependencies) in the scan YAML file.

--- a/_includes/dataset-metrics.md
+++ b/_includes/dataset-metrics.md
@@ -1,4 +1,4 @@
-| Dataset metric | Description      |
-| ---------- | ---------------- |
-| `row_count` | The number of rows in a dataset. |
-| `schema` | A list of column names in a dataset, and their data types. |
+| Dataset metric <br />in Soda SQL |Dataset metric <br />in Soda Cloud | Description      |
+| ---------- | ---------------- | -------------|
+| `row_count` | Row Count  |The number of rows in a dataset. |
+| `schema` | n/a | A list of column names in a dataset, and their data types. |

--- a/soda-cloud/collaborate.md
+++ b/soda-cloud/collaborate.md
@@ -26,7 +26,7 @@ Invite the members of your team to join you in your work to monitor data quality
 
 In Soda Cloud, navigate to **your avatar** > **Invite Team Members** and fill in the blanks. 
 
-When your team members receive the invitation email, they can click the link in the email to create their own accounts and access your Soda Cloud datasets, monitors, and monitor results directly. They can also create new monitors in your account. <!--Be aware that anyone with access to the invitation link in the email can create a Soda Cloud account and access your information.-->
+When your team members receive the invitation email, they can click the link in the email to create their own accounts and access your Soda Cloud datasets, monitors, and monitor results directly. They can also create new monitors in your account. 
 
 ## Share test results
 

--- a/soda-sql/sql_metrics.md
+++ b/soda-sql/sql_metrics.md
@@ -32,7 +32,10 @@ Use **dataset metrics** to define tests in your scan YAML file that execute agai
 
 ![table-metrics](/assets/images/table-metrics.png){:height="440px" width="440px"}
 
-{% include dataset-metrics.md %}
+| Dataset metric <br />in Soda SQL | Description      |
+| ---------- | ---------------- | -------------|
+| `row_count` | The number of rows in a dataset. |
+| `schema` | A list of column names in a dataset, and their data types. |
 
 
 #### Example tests using a dataset metric
@@ -64,7 +67,26 @@ Where a column metric references a valid or invalid value, or a limit, use the m
 See [Metrics examples]({% link soda-sql/examples-by-metric.md %}).
 
 
-{% include column-metrics.md %}
+| Column metric<br /> in Soda SQL | Description |  Applies to [data type]({% link soda/supported-data-types.md %}) | Column config key(s) / Validity Rule(s) | 
+| ----------------------- | ----------- | --------------------- | ----------------------------- | 
+| `avg`| The calculated average of the values in a numeric column. | number |  - | 
+| `avg_length` |  The average length of string values in a column.  | text  |  -  |
+| `invalid_count` |  The number of rows that contain invalid values. | text  | `valid_format` <br /> `valid_regex` <br /> `valid_values` <br /> `valid_min_length` <br /> `valid_max_length`|
+| `invalid_percentage` | The percentage of rows that contain invalid values.  | text  |  `valid_format` <br /> `valid_regex` <br />`valid_values`<br /> `valid_min_length` <br /> `valid_max_length` |
+| `max` |  The greatest value in a numeric column. |  number  |  -  |
+| `max_length` |  The maximum length of string values in a column. |  text  |  -  |
+| `min` |  The smallest value in a numeric column.  | number |  -  |
+| `min_length` |  The minimum length of string values in a column.  | text  |  -  |
+| `missing_count` |  The number of rows in a column that do not contain specific content. | text, number, date  | `missing_format` <br /> `missing_regex` <br /> `missing_values`  |
+| `missing_percentage` |  The percentage of rows in a column that do not contain specific content. | text, number, date  | `missing_format` <br /> `missing_regex` <br /> `missing_values`|
+| `row_count` | The number of rows in a column. |  text, number, date | - |
+| `stddev` |  The calculated standard deviation of values in a numeric column. | number | - |
+| `sum` | The calculated sum of the values in a numeric column.   | number | -  |
+| `valid_count` |   The number of rows that contain valid content.  | text  | `valid_format` <br /> `valid_regex` <br /> `valid_values` <br /> `valid_min_length` <br /> `valid_max_length` |
+| `valid_percentage` |  The percentage of rows that contain valid content.  |  text |  `valid_format` <br /> `valid_regex` <br /> `valid_values` <br /> `valid_min_length` <br /> `valid_max_length` |
+| `values_count` |  The number of rows that contain content included in a list of valid values. |  text | `valid_values` <br /> `valid_regex` |
+| `values_percentage` |  The percentage of rows that contain content identified by valid values. | text | `valid_values` <br /> `valid_regex` |
+| `variance` |  The calculated variance of the values in a numeric column.  | number  | - |
 
 
 ### Column configuration keys

--- a/soda-sql/sql_metrics.md
+++ b/soda-sql/sql_metrics.md
@@ -71,22 +71,22 @@ See [Metrics examples]({% link soda-sql/examples-by-metric.md %}).
 | ----------------------- | ----------- | --------------------- | ----------------------------- | 
 | `avg`| The calculated average of the values in a numeric column. | number |  - | 
 | `avg_length` |  The average length of string values in a column.  | text  |  -  |
-| `invalid_count` |  The number of rows that contain invalid values. | text  | `valid_format` <br /> `valid_regex` <br /> `valid_values` <br /> `valid_min_length` <br /> `valid_max_length`|
-| `invalid_percentage` | The percentage of rows that contain invalid values.  | text  |  `valid_format` <br /> `valid_regex` <br />`valid_values`<br /> `valid_min_length` <br /> `valid_max_length` |
-| `max` |  The greatest value in a numeric column. |  number  |  -  |
+| `invalid_count` |  The number of rows that contain invalid values. | text, number, time   | `valid_format` <br /> `valid_regex` <br /> `valid_values` <br /> `valid_min_length` <br /> `valid_max_length`|
+| `invalid_percentage` | The percentage of rows that contain invalid values.  | text, number, time   |  `valid_format` <br /> `valid_regex` <br />`valid_values`<br /> `valid_min_length` <br /> `valid_max_length` |
+| `max` |  The greatest value in a numeric column. |  number, time  |  -  |
 | `max_length` |  The maximum length of string values in a column. |  text  |  -  |
-| `min` |  The smallest value in a numeric column.  | number |  -  |
+| `min` |  The smallest value in a numeric column.  | number, time |  -  |
 | `min_length` |  The minimum length of string values in a column.  | text  |  -  |
-| `missing_count` |  The number of rows in a column that do not contain specific content. | text, number, date  | `missing_format` <br /> `missing_regex` <br /> `missing_values`  |
-| `missing_percentage` |  The percentage of rows in a column that do not contain specific content. | text, number, date  | `missing_format` <br /> `missing_regex` <br /> `missing_values`|
-| `row_count` | The number of rows in a column. |  text, number, date | - |
+| `missing_count` |  The number of rows in a column that do not contain specific content. | text, number, time  | `missing_format` <br /> `missing_regex` <br /> `missing_values`  |
+| `missing_percentage` |  The percentage of rows in a column that do not contain specific content. | text, number, time  | `missing_format` <br /> `missing_regex` <br /> `missing_values`|
+| `row_count` | The number of rows in a column. |  text, number, time | - |
 | `stddev` |  The calculated standard deviation of values in a numeric column. | number | - |
 | `sum` | The calculated sum of the values in a numeric column.   | number | -  |
-| `valid_count` |   The number of rows that contain valid content.  | text  | `valid_format` <br /> `valid_regex` <br /> `valid_values` <br /> `valid_min_length` <br /> `valid_max_length` |
-| `valid_percentage` |  The percentage of rows that contain valid content.  |  text |  `valid_format` <br /> `valid_regex` <br /> `valid_values` <br /> `valid_min_length` <br /> `valid_max_length` |
-| `values_count` |  The number of rows that contain content included in a list of valid values. |  text | `valid_values` <br /> `valid_regex` |
-| `values_percentage` |  The percentage of rows that contain content identified by valid values. | text | `valid_values` <br /> `valid_regex` |
-| `variance` |  The calculated variance of the values in a numeric column.  | number  | - |
+| `valid_count` |   The number of rows that contain valid content.  | text, number, time  | `valid_format` <br /> `valid_regex` <br /> `valid_values` <br /> `valid_min_length` <br /> `valid_max_length` |
+| `valid_percentage` |  The percentage of rows that contain valid content.  |  text, number, time |  `valid_format` <br /> `valid_regex` <br /> `valid_values` <br /> `valid_min_length` <br /> `valid_max_length` |
+| `values_count` |  The number of rows that contain content included in a list of valid values. |  text, number, time | `valid_values` <br /> `valid_regex` |
+| `values_percentage` |  The percentage of rows that contain content identified by valid values. | text, number, time | `valid_values` <br /> `valid_regex` |
+| `variance` |  The calculated variance of the values in a numeric column.  | number, time  | - |
 
 
 ### Column configuration keys

--- a/soda/metrics.md
+++ b/soda/metrics.md
@@ -25,7 +25,6 @@ Use **dataset metrics** in tests that execute against all data in the dataset du
 
 {% include dataset-metrics.md %}
 
-
 ## Column metrics
 
 Use **column metrics** in tests that execute against specific columns in a dataset during a scan.

--- a/soda/new-documentation.md
+++ b/soda/new-documentation.md
@@ -8,6 +8,10 @@ parent: Soda
 
 <br />
 
+#### September 17, 2021
+
+* Added Soda Cloud metric names to [master list of column metrics]({% link soda/metrics.md %}#column-metrics).
+
 #### September 9, 2021
 
 * Published documentation for [time partitioning]({% link soda-cloud/time-partitioning.md %}), [column metrics]({% link soda-cloud/display-column-metrics.md %}), and [sample data]({% link soda-cloud/display-samples.md %}) in Soda Cloud.

--- a/soda/product-overview.md
+++ b/soda/product-overview.md
@@ -53,7 +53,7 @@ Get started with the [Quick start tutorial for Soda Cloud]({% link soda-cloud/qu
 |	| Create [alerts]({% link soda/glossary.md %}#alert) and [notifications]({% link soda/glossary.md %}#notification) |
 |Configure scan YAML to send <br />[failed row samples]({% link soda-sql/send-failed-rows.md %}) to Soda Cloud | Use a missing value metric type to [collect failed row samples]({% link soda-cloud/failed-rows.md %}#use-a-missing-value-metric-type-to-collect-failed-row-samples)|
 |   | View [failed rows]({% link soda-cloud/failed-rows.md %}) |
-| Configure scan YAML to send <br />[sample dataset data]({% link soda-sql/samples.md %}) to Soda Cloud | <!--[Enable sample data]({% link soda-cloud/display-samples.md %}) for a dataset--> | 
+| Configure scan YAML to send <br />[sample dataset data]({% link soda-sql/samples.md %}) to Soda Cloud | [Enable sample data]({% link soda-cloud/display-samples.md %}) for a dataset | 
 |   | View sample data for a dataset | 
 |	| Use [anomaly detection]({% link soda-cloud/anomaly-detection.md %}) |
 |   | [Collaborate]({% link soda-cloud/collaborate.md %}) with your team to monitor your data: invite team members, and integrate with Slack


### PR DESCRIPTION
To the list of column metrics, and the list of dataset metrics, added the names that Soda Cloud uses. 
To be updated again shortly when several column metrics are removed from the list of available choices.
The search is not yielding expected results when searching for the newly added terms in the metrics tables. Is it because the strings are in a table? More research is needed but doesn't block this PR.