### PR TITLE
fix typos and bash profile nuances in m1 install instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor
 .jekyll-cache
 .bundle/**
 **.DS_Store
+Brewfile

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ $ bundle exec jekyll serve
 ```
 2. As instructed in the command-line output, run the following two commands one-by-one, adjusting the value for YOURNAME in the filepath:
 ```shell
- echo ‘eval “$)/opt/homebrew/bin/brew shellenv)”’ >> /Users/YOURNAME/.bash_profile
+ echo 'eval "$)/opt/homebrew/bin/brew shellenv)"' >> /Users/YOURNAME/.bash_profile
  
- eval “$(/opt/homebrew/bin/brew shellenv)”
+ eval "$(/opt/homebrew/bin/brew shellenv)"
  ```
 3. Optionally, run:  `brew bundle dump`.
 4. Install Ruby using the following command. Note that you can use [`rbenv`](https://github.com/rbenv/rbenv/blob/master/README.md) to install Ruby if you have need to access multiple versions of Ruby on your machine.  

--- a/README.md
+++ b/README.md
@@ -43,29 +43,37 @@ $ bundle exec jekyll serve
 #### Install Ruby on Mac with an Apple M1 chip
 
 1. If you have not already done so, install Homebrew by running the following command in Terminal.   
-```shell
+```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
-2. As instructed in the command-line output, run the following two commands one-by-one, adjusting the value for YOURNAME in the filepath:
-```shell
- echo 'eval "$)/opt/homebrew/bin/brew shellenv)"' >> /Users/YOURNAME/.bash_profile
- 
- eval "$(/opt/homebrew/bin/brew shellenv)"
- ```
+2. As instructed in the command-line output, run the following two commands one-by-one. Make sure to replace the target of `echo` to your bash profile file:
+```bash
+echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> /your/bash/profile/file
+
+eval "$(/opt/homebrew/bin/brew shellenv)"
+```
+Make sure to replace the target of `echo` to your bash profile file. It will typically look something like the following:
+
+```bash
+ echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.bash_profile
+```
+
+If you're not sure which shell you're using, and therefore, which bash profile file this [blogpost](https://www.moncefbelyamani.com/which-shell-am-i-using-how-can-i-switch/) might be helpful.
+
 3. Optionally, run:  `brew bundle dump`.
 4. Install Ruby using the following command. Note that you can use [`rbenv`](https://github.com/rbenv/rbenv/blob/master/README.md) to install Ruby if you have need to access multiple versions of Ruby on your machine.  
 ```shell
 brew install ruby
 ```
 5. Check the Ruby install by running:   `ruby -v`
-6. Add the following to your `~/.bash_profile`, then save the file.
+6. Add the following to your bash profile file, then save the file.
 ```shell
 export PATH="/opt/homebrew/opt/ruby/bin:$PATH"
 export LDFLAGS="-L/opt/homebrew/opt/ruby/lib"
 export CPPFLAGS="-I/opt/homebrew/opt/ruby/include"
 export PKG_CONFIG_PATH="/opt/homebrew/opt/ruby/lib/pkgconfig"
 ```
-7. Restart Terminal.
+7. Source your freshly modified bash profile `source /your/bash_profile/file` or open a new terminal window.
 8. Follow the [Set up docs tooling](#set-up-docs-tooling) above, starting at step 2.
 
 ## Style guidelines


### PR DESCRIPTION
The M1 instructions actually worked like a charm @janet-can! Only, there were a few typos with quotes that probably came from a typographic code editor rather than a plain text one and I also added a few nuances on the bash profile as it can be different depending on the shell people use. I also added a link to a nice blogpost that helps people who might not know.

Feel free to reword any of these instructions if they're not clear enough though and if you think rather than linking to the blogpost on the profile files we should just have it in our docs (for posterity etc.) then I would say go for it.
