### PR TITLE
change: add `method` + `datatype` approach, add population stability index and wasserstein distance

### DIFF
--- a/soda-cl/distribution.md
+++ b/soda-cl/distribution.md
@@ -143,7 +143,7 @@ checks for your_dataset_name:
 * `your_dataset_name` - the name of your dataset
 * `column_name` - the column against which to compare the DRO
 * `> 0.05` - the threshold for the distribution check that you specify as acceptable
-*  `your_method_of_choice` - the type of test you want to use in the distribution check. You can choose one of the following options: `ks`, `chi_square`, `psi`, `swd`, `semd`, corresponding to the Kolmogorov-Smirnov test, Chi-square test, Population Stability Index, Standardized Wasserstein Distance (SWD), and the Standardized Earth Mover's Distance (SEMD). Please note that the SWD and the SEMD are the same metric.
+*  `your_method_of_choice` - the type of test you want to use in the distribution check. You can choose one of the following options: `ks`, `chi_square`, `psi`, `swd`, `semd`, corresponding to the Kolmogorov-Smirnov test, Chi-square test, Population Stability Index, Standardized Wasserstein Distance (SWD), and the Standardized Earth Mover's Distance (SEMD). Please note that the SWD and the SEMD are the same metric. If no method is specified the distribution check defaults to `ks` or `chi_square`, for continuous and categorical data respectively.
 4. Run a soda scan of your data source to execute the distribution check(s) you defined. Refer to <a href ="https://docs.soda.io/soda-core/first-scan.html#run-a-scan" target="_blank">Soda Core documentation</a> for more details.
 ```bash
 soda scan -d your_datasource_name checks.yml -c /path/to/your_configuration_file.yaml your_check_file.yaml

--- a/soda-cl/distribution.md
+++ b/soda-cl/distribution.md
@@ -143,7 +143,7 @@ checks for your_dataset_name:
 * `your_dataset_name` - the name of your dataset
 * `column_name` - the column against which to compare the DRO
 * `> 0.05` - the threshold for the distribution check that you specify as acceptable
-*  `your_method_of_choice` - the type of test you want to use in the distribution check. You can choose one of the following options: `ks`, `chi_square`, `psi`, `swd`, `semd`, corresponding to the Kolmogorov-Smirnov test, Chi-square test, Population Stability Index, Standardized Wasserstein Distance (SWD), and the Standardized Earth Mover's Distance (SEMD). Please note that the SWD and the SEMD are the same metric. If no method is specified the distribution check defaults to `ks` or `chi_square`, for continuous and categorical data respectively.
+*  `your_method_of_choice` - the type of test you want to use in the distribution check. You can choose one of the following options: `ks`, `chi_square`, `psi`, `swd`, `semd`, corresponding to the Kolmogorov-Smirnov test, Chi-square test, Population Stability Index, Standardized Wasserstein Distance (SWD), and the Standardized Earth Mover's Distance (SEMD). Please note that the SWD and the SEMD are the same metric. If no `method` is specified the distribution check defaults to `ks` or `chi_square`, for continuous and categorical data respectively.
 4. Run a soda scan of your data source to execute the distribution check(s) you defined. Refer to <a href ="https://docs.soda.io/soda-core/first-scan.html#run-a-scan" target="_blank">Soda Core documentation</a> for more details.
 ```bash
 soda scan -d your_datasource_name checks.yml -c /path/to/your_configuration_file.yaml your_check_file.yaml

--- a/soda-cl/distribution.md
+++ b/soda-cl/distribution.md
@@ -32,17 +32,19 @@ checks for dim_customer:
 
 To detect changes in the distribution of a column between different points in time, Soda uses approaches based on <a href="https://en.wikipedia.org/wiki/Statistical_hypothesis_testing" target="_blank">hypothesis testing</a> and based on metrics that quantify the distance between samples.  
 
-When using hypothesis testing, a distribution check allows you to determine whether enough evidence exists to conclude that the distribution of a column has changed. It returns the probability that the difference between samples taken at two points in time would have occurred if they came from the same distribution (see <a href="https://en.wikipedia.org/wiki/P-value" target="_blank">p-value</a>). If this probability is smaller than a threshold that you define, the check warns you that the column's distribution has changed.
+When using hypothesis testing, a distribution check allows you to determine whether enough evidence exists to conclude that the distribution of a column has changed. It returns the probability that the difference between samples taken at two points in time would have occurred if they came from the same distribution (see <a href="https://en.wikipedia.org/wiki/P-value" target="_blank">p-value</a>). If this probability is smaller than a threshold that you define, the check warns you that the column's distribution has changed. 
+
+You can use the following statistical tests for hypothesis testing in your distribution checks.
+* <a href="https://en.wikipedia.org/wiki/Kolmogorov%E2%80%93Smirnov_test" target="_blank">Kolmogorov-Smirnov</a> for continuous data
+* <a href="https://en.wikipedia.org/wiki/Chi-squared_test" target="_blank">Chi-square</a> for categorical data
 
 When using a metric to measure distance between samples, a distribution check returns the value of the distance metric that you chose based on samples taken at two points in time. If the value of the distance metric is larger than a threshold that you define, the check warns that the column's distribution has changed.
 
-You can use the following statistical tests and distance metrics in your distribution checks
-* <a href="https://en.wikipedia.org/wiki/Kolmogorov%E2%80%93Smirnov_test" target="_blank">Kolmogorov-Smirnov</a> (hypothesis testing)
-* <a href="https://en.wikipedia.org/wiki/Chi-squared_test" target="_blank">Chi-square</a> (hypothesis testing)
-* <a href="https://mwburke.github.io/data%20science/2018/04/29/population-stability-index.html" target="_blank">Population Stability Index (PSI)</a> (distance metric)
-* <a href="https://en.wikipedia.org/wiki/Wasserstein_metric" target="_blank">Standardized Wasserstein Distance (SWD) </a> (distance metric, standardized using the sample standard deviation)
+You can use the following distance metrics in your distribution checks.
 
-Please make sure that your depending on whether your data is continuous or categorical, you choose a test that is appropriate. While the PSI and the SWD can be used with both types of data, the Kolmogorov-Smirnov test and chi-square test only support continuous and categorical data, respectively.
+* <a href="https://mwburke.github.io/data%20science/2018/04/29/population-stability-index.html" target="_blank">Population Stability Index (PSI)</a> for continuous or categorical data
+* <a href="https://en.wikipedia.org/wiki/Wasserstein_metric" target="_blank">Standardized Wasserstein Distance (SWD) </a> (standardized using the sample standard deviation) for continuous or categorical data
+
 
 <details>
   <summary>Sample sizes in distribution checks</summary>
@@ -56,13 +58,15 @@ Please make sure that your depending on whether your data is continuous or categ
 </details>
 <details>
   <summary>Distribution check thresholds for distance metrics</summary>
-  The values of the Population Stability Index (PSI) and the Standardized Wasserstein Distance (SWD) can be hard to interpret, which is why users are encouraged to investigate which distribution thresholds make sense for their use case. That being said, some common interpretations of the PSI result are
+  The values of the Population Stability Index (PSI) and the Standardized Wasserstein Distance (SWD) can be hard to interpret. Consider carefully investigating which distribution thresholds make sense for your use case. <br />
+  <br />
+  Some common interpretations of the PSI result are as follows:
   <ul>
     <li> PSI < 0.1: no significant distribution change </li>
     <li> 0.1 < PSI < 0.2: moderate distribution change </li>
     <li> PSI >= 0.2: significant distribution change </li>
   </ul>
-  During simulations it was found that for a difference in mean between distributions of size relative to 10% of their standard deviation, the SWD value converged to approximately 0.1.
+  During simulations, for a difference in mean between distributions of size relative to 10% of their standard deviation, the SWD value converged to approximately 0.1.
 </details>
 ## Prerequisites
 
@@ -95,9 +99,7 @@ data_type: categorical
 filter: "column_name between '2010-01-01' and '2020-01-01'"
 ```
 3. Change the values for `table` and `column` to reflect your own dataset's identifiers.
-4. (Optional) Change the value for `data_type` to capture a different data type
-* use `categorical` for categorical data
-* use `continuous` for continuous data
+4. (Optional) Change the value for `data_type` to capture `categorical` or `continuous` data.
 5. (Optional) Define the value of `filter` to specify the portion of the data in your dataset for which you are creating a DRO. If you trained a model on data in which the `date_first_customer` column contained values between 2010-01-01 and 2020-01-01, you can use a filter based on that period to test whether the distribution of the column has changed since then. <br />
 If you do not wish to define a filter, remove the key-value pair from the file.
 6. Save the file, then, while still in your Soda project directory, run the `soda update` command to create a distribution reference object. For a list of options available to use with the command, run `soda update --help`. 
@@ -143,8 +145,14 @@ checks for your_dataset_name:
 * `your_dataset_name` - the name of your dataset
 * `column_name` - the column against which to compare the DRO
 * `> 0.05` - the threshold for the distribution check that you specify as acceptable
-*  `your_method_of_choice` - the type of test you want to use in the distribution check. You can choose one of the following options: `ks`, `chi_square`, `psi`, `swd`, `semd`, corresponding to the Kolmogorov-Smirnov test, Chi-square test, Population Stability Index, Standardized Wasserstein Distance (SWD), and the Standardized Earth Mover's Distance (SEMD). Please note that the SWD and the SEMD are the same metric. If no `method` is specified the distribution check defaults to `ks` or `chi_square`, for continuous and categorical data respectively.
-4. Run a soda scan of your data source to execute the distribution check(s) you defined. Refer to <a href ="https://docs.soda.io/soda-core/first-scan.html#run-a-scan" target="_blank">Soda Core documentation</a> for more details.
+4. Replace the value of `your_method_of_choice` with the type of test you want to use in the distribution check. 
+    * `ks` for the Kolmogorov-Smirnov test
+    * `chi_square` for the Chi-square test
+    * `psi` for the Population Stability Index metric
+    * `swd` for the Standardized Wasserstein Distance (SWD) metric 
+    * `semd` for the Standardized Earth Mover's Distance (SEMD) metric (the SWD and the SEMD are the same metric) <br /> 
+If you do not specify a `method`, the distribution check defaults to `ks` for continuous data or `chi_square` for categorical data respectively.
+5. Run a soda scan of your data source to execute the distribution check(s) you defined. Refer to <a href ="https://docs.soda.io/soda-core/first-scan.html#run-a-scan" target="_blank">Soda Core documentation</a> for more details.
 ```bash
 soda scan -d your_datasource_name checks.yml -c /path/to/your_configuration_file.yaml your_check_file.yaml
 ```

--- a/soda-cl/distribution.md
+++ b/soda-cl/distribution.md
@@ -35,6 +35,7 @@ To detect changes in the distribution of a column between different points in ti
 When using hypothesis testing, a distribution check allows you to determine whether enough evidence exists to conclude that the distribution of a column has changed. It returns the probability that the difference between samples taken at two points in time would have occurred if they came from the same distribution (see <a href="https://en.wikipedia.org/wiki/P-value" target="_blank">p-value</a>). If this probability is smaller than a threshold that you define, the check warns you that the column's distribution has changed. 
 
 You can use the following statistical tests for hypothesis testing in your distribution checks.
+
 * <a href="https://en.wikipedia.org/wiki/Kolmogorov%E2%80%93Smirnov_test" target="_blank">Kolmogorov-Smirnov</a> for continuous data
 * <a href="https://en.wikipedia.org/wiki/Chi-squared_test" target="_blank">Chi-square</a> for categorical data
 

--- a/soda-cl/distribution.md
+++ b/soda-cl/distribution.md
@@ -90,12 +90,12 @@ To create a DRO, you use the CLI command `soda update`. When you execute the com
 ```yaml
 table: your_dataset_name
 column: column_name_in_dataset
-datatype: categorical
+data_type: categorical
 # (optional) filter to a specific point in time or any other dimension 
 filter: "column_name between '2010-01-01' and '2020-01-01'"
 ```
 3. Change the values for `table` and `column` to reflect your own dataset's identifiers.
-4. (Optional) Change the value for `datatype` to capture a different data type
+4. (Optional) Change the value for `data_type` to capture a different data type
 * use `categorical` for categorical data
 * use `continuous` for continuous data
 5. (Optional) Define the value of `filter` to specify the portion of the data in your dataset for which you are creating a DRO. If you trained a model on data in which the `date_first_customer` column contained values between 2010-01-01 and 2020-01-01, you can use a filter based on that period to test whether the distribution of the column has changed since then. <br />
@@ -109,7 +109,7 @@ soda update -d your_datasource_name -c your_configuration_file.yaml ./distributi
 ```yaml
 table: dim_customer
 column: number_cars_owned
-datatype: categorical
+data_type: categorical
 filter: date_first_purchase between '2010-01-01' and '2020-01-01'
 distribution reference:
   weights:
@@ -127,7 +127,7 @@ distribution reference:
 ```
 Soda appended a new key called `distribution reference` to the file, together with an array of `bins` and a corresponding array of `weights`. 
 
-Soda uses the `bins` and `weights` to generate a sample from the reference distribution when it executes the distribution check during a scan. By creating a sample using the DRO's bins and weights, you do not have to save the entire – potentially very large - sample. The `datatype` value impacts how the weights and bins will be used to generate a sample, so make sure your choice reflects the nature of your data (continuous or categorical).
+Soda uses the `bins` and `weights` to generate a sample from the reference distribution when it executes the distribution check during a scan. By creating a sample using the DRO's bins and weights, you do not have to save the entire – potentially very large - sample. The `data_type` value impacts how the weights and bins will be used to generate a sample, so make sure your choice reflects the nature of your data (continuous or categorical).
 
 ## Define a distribution check
 
@@ -148,7 +148,7 @@ checks for your_dataset_name:
 ```bash
 soda scan -d your_datasource_name checks.yml -c /path/to/your_configuration_file.yaml your_check_file.yaml
 ```
-When the above distribution check is executed, it compares the values in `column_name` to a sample that Soda creates based on the `bins`, `weights`, and `datatype` defined in the `distribution_reference.yml` file. Specifically, it checks whether the value of `your_method_of_choice` is larger than `0.05`.
+When the above distribution check is executed, it compares the values in `column_name` to a sample that Soda creates based on the `bins`, `weights`, and `data_type` defined in the `distribution_reference.yml` file. Specifically, it checks whether the value of `your_method_of_choice` is larger than `0.05`.
 
 When you execute the `soda scan` command, Soda stores the entire contents of the column(s) you specified in local memory. Before executing the command, examine the volume of data the column(s) contains and ensure that your system can accommodate storing it in local memory. 
 

--- a/soda-cl/distribution.md
+++ b/soda-cl/distribution.md
@@ -13,6 +13,7 @@ Use a distribution check to determine whether the distribution of a column has c
 checks for dim_customer:
   - distribution_difference(number_cars_owned) > 0.05:
       distribution reference file: ./cars_owned_dist_ref.yml
+      method: chi_square
 ```
 
 [About distribution checks](#about-distribution-checks)<br />
@@ -27,13 +28,21 @@ checks for dim_customer:
 [Go further](#go-further) <br />
 <br />
 
-
 ## About distribution checks
 
-To detect changes in the distribution of a column between different points in time, Soda uses <a href="https://en.wikipedia.org/wiki/Statistical_hypothesis_testing" target="_blank"> statistical hypothesis testing</a>. In essence, a distribution check allows you to determine whether enough evidence exists to conclude that the distribution of a column has changed. It returns the probability that the difference between samples taken at two points in time would have occurred if they came from the same distribution (see <a href="https://en.wikipedia.org/wiki/P-value" target="_blank">p-value</a>). If this probability is smaller than a threshold that you define, the check warns you that the column's distribution has changed.
+To detect changes in the distribution of a column between different points in time, Soda uses approaches based on <a href="https://en.wikipedia.org/wiki/Statistical_hypothesis_testing" target="_blank">hypothesis testing</a> and based on metrics that quantify the distance between samples.  
 
-Depending on whether your data is categorical or continuous, use the <a href="https://en.wikipedia.org/wiki/Chi-squared_test" target="_blank">chi-square</a> test or the <a href="https://en.wikipedia.org/wiki/Kolmogorov%E2%80%93Smirnov_test" target="_blank">Kolmogorov-Smirnov</a> test, respectively.
+When using hypothesis testing, a distribution check allows you to determine whether enough evidence exists to conclude that the distribution of a column has changed. It returns the probability that the difference between samples taken at two points in time would have occurred if they came from the same distribution (see <a href="https://en.wikipedia.org/wiki/P-value" target="_blank">p-value</a>). If this probability is smaller than a threshold that you define, the check warns you that the column's distribution has changed.
 
+When using a metric to measure distance between samples, a distribution check returns the value of the distance metric that you chose based on samples taken at two points in time. If the value of the distance metric is larger than a threshold that you define, the check warns that the column's distribution has changed.
+
+You can use the following statistical tests and distance metrics in your distribution checks
+* <a href="https://en.wikipedia.org/wiki/Kolmogorov%E2%80%93Smirnov_test" target="_blank">Kolmogorov-Smirnov</a> (hypothesis testing)
+* <a href="https://en.wikipedia.org/wiki/Chi-squared_test" target="_blank">Chi-square</a> (hypothesis testing)
+* <a href="https://mwburke.github.io/data%20science/2018/04/29/population-stability-index.html" target="_blank">Population Stability Index (PSI)</a> (distance metric)
+* <a href="https://en.wikipedia.org/wiki/Wasserstein_metric" target="_blank">Standardized Wasserstein Distance (SWD) </a> (distance metric, standardized using the sample standard deviation)
+
+Please make sure that your depending on whether your data is continuous or categorical, you choose a test that is appropriate. While the PSI and the SWD can be used with both types of data, the Kolmogorov-Smirnov test and chi-square test only support continuous and categorical data, respectively.
 
 <details>
   <summary>Sample sizes in distribution checks</summary>
@@ -45,7 +54,16 @@ Depending on whether your data is categorical or continuous, use the <a href="ht
   <br /><br />
   For each distribution type, the Kolmogorov-Smirnov test rejected the null hypothesis 100% of the time if the effect size was equal to, or larger than, a shift to the mean of 1% of the standard deviation, when using a sample size of one million. Using such a sample size does not result in problems with local memory.
 </details>
-
+<details>
+  <summary>Distribution check thresholds for distance metrics</summary>
+  The values of the Population Stability Index (PSI) and the Standardized Wasserstein Distance (SWD) can be hard to interpret, which is why users are encouraged to investigate which distribution thresholds make sense for their use case. That being said, some common interpretations of the PSI result are
+  <ul>
+    <li> PSI < 0.1: no significant distribution change </li>
+    <li> 0.1 < PSI < 0.2: moderate distribution change </li>
+    <li> PSI >= 0.2: significant distribution change </li>
+  </ul>
+  During simulations it was found that for a difference in mean between distributions of size relative to 10% of their standard deviation, the SWD value converged to approximately 0.1.
+</details>
 ## Prerequisites
 
 * You have [installed Soda Core Scientific](#install-soda-core-scientific) in the same directory or virtual environment in which you <a href="https://docs.soda.io/soda-core/get-started.html#requirements" target="_blank">installed Soda Core</a>.
@@ -72,14 +90,14 @@ To create a DRO, you use the CLI command `soda update`. When you execute the com
 ```yaml
 table: your_dataset_name
 column: column_name_in_dataset
-method: chi_square
+datatype: categorical
 # (optional) filter to a specific point in time or any other dimension 
 filter: "column_name between '2010-01-01' and '2020-01-01'"
 ```
 3. Change the values for `table` and `column` to reflect your own dataset's identifiers.
-4. (Optional) Change the value for `method` to instruct the distribution check which type of test to use. 
-* use `chi_square` for categorical data; see <a href="https://en.wikipedia.org/wiki/Chi-squared_test" target="_blank">chi-square</a>
-* use `ks` for continuous data; see <a href="https://en.wikipedia.org/wiki/Kolmogorov%E2%80%93Smirnov_test" target="_blank">Kolmogorov-Smirnov</a>
+4. (Optional) Change the value for `datatype` to capture a different data type
+* use `categorical` for categorical data
+* use `continuous` for continuous data
 5. (Optional) Define the value of `filter` to specify the portion of the data in your dataset for which you are creating a DRO. If you trained a model on data in which the `date_first_customer` column contained values between 2010-01-01 and 2020-01-01, you can use a filter based on that period to test whether the distribution of the column has changed since then. <br />
 If you do not wish to define a filter, remove the key-value pair from the file.
 6. Save the file, then, while still in your Soda project directory, run the `soda update` command to create a distribution reference object. For a list of options available to use with the command, run `soda update --help`. 
@@ -91,7 +109,7 @@ soda update -d your_datasource_name -c your_configuration_file.yaml ./distributi
 ```yaml
 table: dim_customer
 column: number_cars_owned
-method: chi_square
+datatype: categorical
 filter: date_first_purchase between '2010-01-01' and '2020-01-01'
 distribution reference:
   weights:
@@ -109,7 +127,7 @@ distribution reference:
 ```
 Soda appended a new key called `distribution reference` to the file, together with an array of `bins` and a corresponding array of `weights`. 
 
-Soda uses the `bins` and `weights` to generate a sample from the reference distribution when it executes the distribution check during a scan. By creating a sample using the DRO's bins and weights, you do not have to save the entire – potentially very large - sample.
+Soda uses the `bins` and `weights` to generate a sample from the reference distribution when it executes the distribution check during a scan. By creating a sample using the DRO's bins and weights, you do not have to save the entire – potentially very large - sample. The `datatype` value impacts how the weights and bins will be used to generate a sample, so make sure your choice reflects the nature of your data (continuous or categorical).
 
 ## Define a distribution check
 
@@ -117,18 +135,21 @@ Soda uses the `bins` and `weights` to generate a sample from the reference distr
 2. In your new file, add the following example content.
 ```yaml
 checks for your_dataset_name:
-  - distribution_difference(column_name) > 0.05:
+  - distribution_difference(column_name) > your_threshold:
+      method: your_method_of_choice
       distribution reference file: ./distribution_reference.yml
 ```
 3. Replace the following values with your own dataset and threshold details.
 * `your_dataset_name` - the name of your dataset
 * `column_name` - the column against which to compare the DRO
-* `> 0.05` - the threshold for the p-value that you specify as acceptable
-This example distribution check compares the values in `column_name` to a sample that Soda creates based on the `bins` and `weights` defined in the `distribution_reference.yml` file. Specifically, it checks whether the p-value of the statistical test is larger than `0.05`.
+* `> 0.05` - the threshold for the distribution check that you specify as acceptable
+*  `your_method_of_choice` - the type of test you want to use in the distribution check. You can choose one of the following options: `ks`, `chi_square`, `psi`, `swd`, `semd`, corresponding to the Kolmogorov-Smirnov test, Chi-square test, Population Stability Index, Standardized Wasserstein Distance (SWD), and the Standardized Earth Mover's Distance (SEMD). Please note that the SWD and the SEMD are the same metric.
 4. Run a soda scan of your data source to execute the distribution check(s) you defined. Refer to <a href ="https://docs.soda.io/soda-core/first-scan.html#run-a-scan" target="_blank">Soda Core documentation</a> for more details.
 ```bash
 soda scan -d your_datasource_name checks.yml -c /path/to/your_configuration_file.yaml your_check_file.yaml
 ```
+When the above distribution check is executed, it compares the values in `column_name` to a sample that Soda creates based on the `bins`, `weights`, and `datatype` defined in the `distribution_reference.yml` file. Specifically, it checks whether the value of `your_method_of_choice` is larger than `0.05`.
+
 When you execute the `soda scan` command, Soda stores the entire contents of the column(s) you specified in local memory. Before executing the command, examine the volume of data the column(s) contains and ensure that your system can accommodate storing it in local memory. 
 
 <br />
@@ -140,10 +161,12 @@ You can define multiple distribution checks in a single `checks.yml` file. If yo
 ```yaml
 checks for dim_customer:
   - distribution_difference(number_cars_owned) > 0.05:
+      method: chi_square
       distribution reference file: ./cars_owned_dist_ref.yml
 
 checks for fact_sales_quota:
-  - distribution_difference(calendar_quarter) > 0.05:
+  - distribution_difference(calendar_quarter) < 0.2:
+      method: psi
       distribution reference file: ./sales_dist_ref.yml
 ```
 
@@ -152,12 +175,15 @@ You can also define multiple checks for different columns in the same dataset by
 ```yaml
 checks for dim_customer:
   - distribution_difference(number_cars_owned) > 0.05:
+      method: chi_square
       distribution reference file: ./cars_owned_dist_ref.yml
-  - distribution_difference(total_children) > 0.05:
+  - distribution_difference(total_children) < 0.2:
+      method: psi
       distribution reference file: ./total_children_dist_ref.yml
 
 checks for fact_sales_quota:
-  - distribution_difference(calendar_quarter) > 0.05:
+  - distribution_difference(calendar_quarter) < 0.15:
+      method: swd
       distribution reference file: ./sales_dist_ref.yml
 ```
 
@@ -177,7 +203,8 @@ checks for fact_sales_quota:
 
 ```yaml
 checks for dim_customer:
-- distribution_difference(number_cars_owned) > 0.05:
+- distribution_difference(number_cars_owned) > 0.05: 
+    method: chi_square
     distribution reference file: dist_ref.yml
     name: Distribution check
 ```
@@ -186,7 +213,8 @@ checks for dim_customer:
 
 ```yaml
 checks for dim_customer:
-- distribution_difference("number_cars_owned") > 0.05:
+- distribution_difference("number_cars_owned") < 0.2:
+    method: psi
     distribution reference file: dist_ref.yml
     name: Distribution check
 ```
@@ -198,7 +226,8 @@ for each table T:
     tables:
         - dim_customer
     checks:
-    - distribution_difference(number_cars_owned, absolutely_whatever_string_you_please) > 0.05:
+    - distribution_difference(number_cars_owned, absolutely_whatever_string_you_please) < 0.15:
+        method: swd
         distribution reference file: dist_ref.yml
 ```
 

--- a/soda/new-documentation.md
+++ b/soda/new-documentation.md
@@ -13,6 +13,7 @@ parent: Soda
 
 * Updated the [Quick start for SodaCL]({% link soda/quick-start-sodacl.md %}) with an example of a check for duplicates.
 * Added documentation for [installing Soda Spark on Windows]({% link soda-spark/install-and-use.md %}#install-soda-spark-on-windows).
+* Updated the [Distribution check]({% link soda-cl/distribution.md %}) documentation to record a change in syntax for the check and the addition of two more methods available to use with distribution checks.
 
 #### June 7, 2022
 


### PR DESCRIPTION
Hi @janet-can,

The changes that I have suggested here ensure that the documentation is up to date with the changes made in [this PR](https://github.com/sodadata/soda-core/pull/1395). The essential changes are:

* Use `method` key in `checks.yml` file and `datatype` key in `distribution_reference.yml` file. This should make more sense for the user and allows them to use the DRO solely for the purpose of sampling from the reference distribution
* Add the population stability index (PSI) and the standardized wasserstein distance (swd) as alternatives to the statistical tests
* Explain difference between statistical tests and metric/distance based checks

This resolves: https://sodadata.atlassian.net/browse/SODA-831