### PR TITLE
Revert "change: 'data_type' key becomes 'distribution_type' key and earth mover's distance is clearly mentioned"

### DIFF
--- a/soda-cl/distribution.md
+++ b/soda-cl/distribution.md
@@ -45,7 +45,6 @@ You can use the following distance metrics in your distribution checks.
 
 * <a href="https://mwburke.github.io/data%20science/2018/04/29/population-stability-index.html" target="_blank">Population Stability Index (PSI)</a> for continuous or categorical data
 * <a href="https://en.wikipedia.org/wiki/Wasserstein_metric" target="_blank">Standardized Wasserstein Distance (SWD) </a> (standardized using the sample standard deviation) for continuous or categorical data
-* <a href="https://en.wikipedia.org/wiki/Earth_mover%27s_distance" target="_blank">Standardized Earth Mover's Distance</a> (standardized using the sample standard deviation, this metric is equal to the SWD) for continuous or categorical data
 
 
 <details>
@@ -96,12 +95,12 @@ To create a DRO, you use the CLI command `soda update`. When you execute the com
 ```yaml
 table: your_dataset_name
 column: column_name_in_dataset
-distribution_type: categorical
+data_type: categorical
 # (optional) filter to a specific point in time or any other dimension 
 filter: "column_name between '2010-01-01' and '2020-01-01'"
 ```
 3. Change the values for `table` and `column` to reflect your own dataset's identifiers.
-4. (Optional) Change the value for `distribution_type` to capture `categorical` or `continuous` data.
+4. (Optional) Change the value for `data_type` to capture `categorical` or `continuous` data.
 5. (Optional) Define the value of `filter` to specify the portion of the data in your dataset for which you are creating a DRO. If you trained a model on data in which the `date_first_customer` column contained values between 2010-01-01 and 2020-01-01, you can use a filter based on that period to test whether the distribution of the column has changed since then. <br />
 If you do not wish to define a filter, remove the key-value pair from the file.
 6. Save the file, then, while still in your Soda project directory, run the `soda update` command to create a distribution reference object. For a list of options available to use with the command, run `soda update --help`. 
@@ -113,7 +112,7 @@ soda update -d your_datasource_name -c your_configuration_file.yaml ./distributi
 ```yaml
 table: dim_customer
 column: number_cars_owned
-distribution_type: categorical
+data_type: categorical
 filter: date_first_purchase between '2010-01-01' and '2020-01-01'
 distribution reference:
   weights:
@@ -131,7 +130,7 @@ distribution reference:
 ```
 Soda appended a new key called `distribution reference` to the file, together with an array of `bins` and a corresponding array of `weights`. 
 
-Soda uses the `bins` and `weights` to generate a sample from the reference distribution when it executes the distribution check during a scan. By creating a sample using the DRO's bins and weights, you do not have to save the entire – potentially very large - sample. The `distribution_type` value impacts how the weights and bins will be used to generate a sample, so make sure your choice reflects the nature of your data (continuous or categorical).
+Soda uses the `bins` and `weights` to generate a sample from the reference distribution when it executes the distribution check during a scan. By creating a sample using the DRO's bins and weights, you do not have to save the entire – potentially very large - sample. The `data_type` value impacts how the weights and bins will be used to generate a sample, so make sure your choice reflects the nature of your data (continuous or categorical).
 
 ## Define a distribution check
 
@@ -158,7 +157,7 @@ If you do not specify a `method`, the distribution check defaults to `ks` for co
 ```bash
 soda scan -d your_datasource_name checks.yml -c /path/to/your_configuration_file.yaml your_check_file.yaml
 ```
-When the above distribution check is executed, it compares the values in `column_name` to a sample that Soda creates based on the `bins`, `weights`, and `distribution_type` defined in the `distribution_reference.yml` file. Specifically, it checks whether the value of `your_method_of_choice` is larger than `0.05`.
+When the above distribution check is executed, it compares the values in `column_name` to a sample that Soda creates based on the `bins`, `weights`, and `data_type` defined in the `distribution_reference.yml` file. Specifically, it checks whether the value of `your_method_of_choice` is larger than `0.05`.
 
 When you execute the `soda scan` command, Soda stores the entire contents of the column(s) you specified in local memory. Before executing the command, examine the volume of data the column(s) contains and ensure that your system can accommodate storing it in local memory. 
 


### PR DESCRIPTION
Reverts sodadata/docs#291

This is because we will need to wait for soda-core to be tagged to a new version for users to be able to use this new interface