### PR TITLE
fix: indentation issues in configuration for soda-core

### DIFF
--- a/_includes/core-datasource-config.md
+++ b/_includes/core-datasource-config.md
@@ -11,24 +11,24 @@ data_source athena:
     database: ${ env_var('ATHENA_DATABASE') }
 ```
 
-| Property  | Required | Notes |
-| --------  | -------- |-------- |
-| type | required |  |
-| access_key_id |  optional | Use environment variables to retrieve this value securely. |
+| Property          | Required | Notes                                                      |
+| ----------------- | -------- | ---------------------------------------------------------- |
+| type              | required |                                                            |
+| access_key_id     | optional | Use environment variables to retrieve this value securely. |
 | secret_access_key | optional | Use environment variables to retrieve this value securely. |
-| region_name |optional |  | 
-| staging_dir |  required |  |
-| database | required |  |
+| region_name       | optional |                                                            |
+| staging_dir       | required |                                                            |
+| database          | required |                                                            |
 
 Access keys and IAM role are mutually exclusive: if you provide values for `access_key_id` and `secret_access_key`, you cannot use Identity and Access Management role; if you provide value for `role_arn`, then you cannot use the access keys. Refer to [Identity and Access Management in Athena](https://docs.aws.amazon.com/athena/latest/ug/security-iam-athena.html) for details.
 
 ### Supported data types
 
-| Category | Data type | 
-| ---- | --------- |
-| text | CHAR, VARCHAR, STRING |
-| number | TINYINT, SMALLINT, INT, INTEGER, BIGINT, DOUBLE, FLOAT, DECIMAL |
-| time | DATE, TIMESTAMP |
+| Category | Data type                                                       |
+| -------- | --------------------------------------------------------------- |
+| text     | CHAR, VARCHAR, STRING                                           |
+| number   | TINYINT, SMALLINT, INT, INTEGER, BIGINT, DOUBLE, FLOAT, DECIMAL |
+| time     | DATE, TIMESTAMP                                                 |
 
 ## Connect to Amazon Redshift
 
@@ -40,69 +40,77 @@ data_source my_database_name:
     username:
     password:
     database: soda_test
-    schema: public
-  access_key_id:
-  secret_access_key:
-  role_arn:
-  region: eu-west-1
+    access_key_id:
+    secret_access_key:
+    role_arn:
+    region: eu-west-1
+  schema: public
 ```
 
-| Property |  Required | Notes |
-| -------- |  -------- | ----- |
-| type    | required |  |
-| host |  required |   |
-| username  |  required |  |
-| password  |  required |  |
-| database  | required |  |
-| schema    |  |  |
-| access_key_id  | optional | Use environment variables to retrieve this value securely. |
-| secret_access_key  | optional | Use environment variables to retrieve this value securely. |
-| role_arn| optional | The [Amazon Resource Name](https://docs.aws.amazon.com/credref/latest/refdocs/setting-global-role_arn.html) of an IAM role that you want to use. |
-| region | optional |  |
+| Property          | Required | Notes                                                                                                                                            |
+| ----------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| type              | required |                                                                                                                                                  |
+| host              | required |                                                                                                                                                  |
+| username          | required |                                                                                                                                                  |
+| password          | required |                                                                                                                                                  |
+| database          | required |                                                                                                                                                  |
+| schema            |          |                                                                                                                                                  |
+| access_key_id     | optional | Use environment variables to retrieve this value securely.                                                                                       |
+| secret_access_key | optional | Use environment variables to retrieve this value securely.                                                                                       |
+| role_arn          | optional | The [Amazon Resource Name](https://docs.aws.amazon.com/credref/latest/refdocs/setting-global-role_arn.html) of an IAM role that you want to use. |
+| region            | optional |                                                                                                                                                  |
 
 Access keys and IAM role are mutually exclusive: if you provide values for `access_key_id` and `secret_access_key`, you cannot use Identity and Access Management role; if you provide value for `role_arn`, then you cannot use the access keys. Refer to [Amazon Redshift Authorization parameters](https://docs.aws.amazon.com/redshift/latest/dg/copy-parameters-authorization.html) for details.
 
 ### Supported data types
 
-| Category | Data type |
-| ---- | --------- |
-| text | CHARACTER VARYING, CHARACTER, CHAR, TEXT, NCHAR, NVARCHAR, BPCHAR |
-| number | SMALLINT, INT2, INTEGER, INT, INT4, BIGINT, INT8 |
-| time | DATE, TIME, TIMETZ, TIMESTAMP, TIMESTAMPTZ |
-
+| Category | Data type                                                         |
+| -------- | ----------------------------------------------------------------- |
+| text     | CHARACTER VARYING, CHARACTER, CHAR, TEXT, NCHAR, NVARCHAR, BPCHAR |
+| number   | SMALLINT, INT2, INTEGER, INT, INT4, BIGINT, INT8                  |
+| time     | DATE, TIME, TIMETZ, TIMESTAMP, TIMESTAMPTZ                        |
 
 ## Connect to Apache Spark DataFrames
 
-* For use with [programmatic Soda scans]({% link soda-core/programmatic-scans.md %}), only. 
-* Unlike other data sources, Soda Core does *not* require a configuration YAML file to run scans against Spark DataFrames. 
+- For use with [programmatic Soda scans]({% link soda-core/programmatic-scans.md %}), only.
+- Unlike other data sources, Soda Core does _not_ require a configuration YAML file to run scans against Spark DataFrames.
 
-Note: There are two Soda Core packages for Spark: 
-* `soda-core-spark-df`, in its early release candidate form, enables you to pass dataframe objects into Soda scans programatically, after you have associated the temporary tables to DataFrames via the Spark API.
-* `soda-core-spark` continues as a work-in-progress and will connect to Soda Core much the same as other data sources, via connection details in a configuration YAML.
+Note: There are two Soda Core packages for Spark:
 
+- `soda-core-spark-df`, in its early release candidate form, enables you to pass dataframe objects into Soda scans programatically, after you have associated the temporary tables to DataFrames via the Spark API.
+- `soda-core-spark` continues as a work-in-progress and will connect to Soda Core much the same as other data sources, via connection details in a configuration YAML.
 
-A Spark cluster contains a distributed collection of data. Spark DataFrames are distributed collections of data that are organized into named columns, much like a table in a database, and which are stored in-memory in a cluster.  To make a DataFrame available to Soda Core to run scans against, you must use a driver program like PySpark and the Spark API to link DataFrames to individual, named, temporary tables in the cluster. You pass this information into a Soda scan programatically.
+A Spark cluster contains a distributed collection of data. Spark DataFrames are distributed collections of data that are organized into named columns, much like a table in a database, and which are stored in-memory in a cluster. To make a DataFrame available to Soda Core to run scans against, you must use a driver program like PySpark and the Spark API to link DataFrames to individual, named, temporary tables in the cluster. You pass this information into a Soda scan programatically.
 
-1. If you are *not* installing Soda Core Spark DataFrames on a cluster, skip to step 2. To install Soda Core Spark DataFrames on a cluster, such as a Kubernetes cluster or a Databricks cluster, install <a href="https://packages.debian.org/buster/libsasl2-dev" target="_blank"> `libsasl2-dev` </a> *before* installing `soda-core-spark-df`. For Ubuntu users, install `libsasl2-dev` using the following command: 
+1. If you are _not_ installing Soda Core Spark DataFrames on a cluster, skip to step 2. To install Soda Core Spark DataFrames on a cluster, such as a Kubernetes cluster or a Databricks cluster, install <a href="https://packages.debian.org/buster/libsasl2-dev" target="_blank"> `libsasl2-dev` </a> _before_ installing `soda-core-spark-df`. For Ubuntu users, install `libsasl2-dev` using the following command:
+
 ```shell
 sh sudo apt-get -y install unixodbc-dev libsasl2-dev gcc python-dev
 ```
+
 2. Confirm that you have already:
-* installed `soda-core-spark-df`
-* set up a a Spark session <br />
+
+- installed `soda-core-spark-df`
+- set up a a Spark session <br />
+
 ```python
 spark_session: SparkSession = ...user-defined-way-to-create-the-spark-session...
 ```
-* your Spark cluster contains one or more DataFrames 
+
+- your Spark cluster contains one or more DataFrames
+
 ```python
 df = ...user-defined-way-to-build-the-dataframe...
 ```
+
 3. Use the Spark API to link the name of a temporary table to a DataFrame. In this example, the name of the table is `customers`.
+
 ```python
 db.createOrReplaceTempView('customers')
 ```
+
 4. Use the Spark API to link a DataFrame to the name of each temporary table against which you wish to run Soda scans. Refer to <a href="https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.DataFrame.createOrReplaceTempView.html" target="_blank"> PySpark documentation</a>.
-5. [Define a programmatic scan]({% link soda-core/programmatic-scans.md %}) for the data in the DataFrames, and include one extra method to pass all the DataFrames to Soda Core: `add_spark_session(self, spark_session, data_source_name: str)`. The default value for `data_source_name` is `"spark_df"`. Refer to the example below. 
+5. [Define a programmatic scan]({% link soda-core/programmatic-scans.md %}) for the data in the DataFrames, and include one extra method to pass all the DataFrames to Soda Core: `add_spark_session(self, spark_session, data_source_name: str)`. The default value for `data_source_name` is `"spark_df"`. Refer to the example below.
 
 ```python
 spark_session = ...your_spark_session...
@@ -127,7 +135,6 @@ scan.add_spark_session(spark_session)
 -->
 
 <br />
-
 
 ## Connect to GCP BigQuery
 
@@ -157,32 +164,31 @@ data_source my_database_name:
     dataset: sodacore
 ```
 
-| Property |  Required |
-| -------- |  -------- |
-| type | required |
-| account_info_json | reqired; inline properties listed below |
-| &ensp;&ensp;type | required |
-| &ensp;&ensp;project_id | required |
-| &ensp;&ensp;private_key_id | required |
-| &ensp;&ensp;private_key | required |
-| &ensp;&ensp;client_email | required |
-| &ensp;&ensp;client_id | required |
-| &ensp;&ensp;auth_uri | required |
-| &ensp;&ensp;token_uri | required |
-| &ensp;&ensp;auth_provider_x509_cert_url | required |
-| &ensp;&ensp;client_x509_cert_url | required |
-| auth_scopes | optional; Soda applies the three scopes listed above by default |
-| project_id | optional; overrides project_id from account_info_json |
-| dataset | required |
+| Property                                | Required                                                        |
+| --------------------------------------- | --------------------------------------------------------------- |
+| type                                    | required                                                        |
+| account_info_json                       | reqired; inline properties listed below                         |
+| &ensp;&ensp;type                        | required                                                        |
+| &ensp;&ensp;project_id                  | required                                                        |
+| &ensp;&ensp;private_key_id              | required                                                        |
+| &ensp;&ensp;private_key                 | required                                                        |
+| &ensp;&ensp;client_email                | required                                                        |
+| &ensp;&ensp;client_id                   | required                                                        |
+| &ensp;&ensp;auth_uri                    | required                                                        |
+| &ensp;&ensp;token_uri                   | required                                                        |
+| &ensp;&ensp;auth_provider_x509_cert_url | required                                                        |
+| &ensp;&ensp;client_x509_cert_url        | required                                                        |
+| auth_scopes                             | optional; Soda applies the three scopes listed above by default |
+| project_id                              | optional; overrides project_id from account_info_json           |
+| dataset                                 | required                                                        |
 
 ### Supported data types
 
-| Category | Data type |
-| ---- | --------- |
-| text | STRING |
-| number | INT64, DECIMAL, BINUMERIC, BIGDECIMAL, FLOAT64 |
-| time | DATE, DATETIME, TIME, TIMESTAMP |
-
+| Category | Data type                                      |
+| -------- | ---------------------------------------------- |
+| text     | STRING                                         |
+| number   | INT64, DECIMAL, BINUMERIC, BIGDECIMAL, FLOAT64 |
+| time     | DATE, DATETIME, TIME, TIMESTAMP                |
 
 ## Connect to PostgreSQL
 
@@ -191,31 +197,30 @@ data_source my_database_name:
   type: postgres
   connection:
     host: db
-    port: '5432'
+    port: "5432"
     username:
     password:
-  database: postgres
+    database: postgres
   schema: public
 ```
 
-| Property |  Required | Notes |
-| -------- |  -------- | ----- |
-| type | required |  |
-| host | required |  |
-| port | optional |  |
-| username| required | Use environment variables to retrieve this value securely.|
-| password| required | Use environment variables to retrieve this value securely.|
-| database| required |  |
-| schema | required | |
+| Property | Required | Notes                                                      |
+| -------- | -------- | ---------------------------------------------------------- |
+| type     | required |                                                            |
+| host     | required |                                                            |
+| port     | optional |                                                            |
+| username | required | Use environment variables to retrieve this value securely. |
+| password | required | Use environment variables to retrieve this value securely. |
+| database | required |                                                            |
+| schema   | required |                                                            |
 
 ### Supported data types
 
-| Category | Data type |
-| ---- | --------- |
-| text | CHARACTER VARYING, CHARACTER, CHAR, TEXT |
-| number | SMALLINT, INTEGER, BIGINT, DECIMAL, NUMERIC, VARIABLE, REAL, DOUBLE PRECISION, SMALLSERIAL, SERIAL, BIGSERIAL |
-| time | TIMESTAMPT, DATE, TIME, TIMESTAMP WITH TIME ZONE, TIMESTAMP WITHOUT TIME ZONE, TIME WITH TIME ZONE, TIME WITHOUT TIME ZONE |
-
+| Category | Data type                                                                                                                  |
+| -------- | -------------------------------------------------------------------------------------------------------------------------- |
+| text     | CHARACTER VARYING, CHARACTER, CHAR, TEXT                                                                                   |
+| number   | SMALLINT, INTEGER, BIGINT, DECIMAL, NUMERIC, VARIABLE, REAL, DOUBLE PRECISION, SMALLSERIAL, SERIAL, BIGSERIAL              |
+| time     | TIMESTAMPT, DATE, TIME, TIMESTAMP WITH TIME ZONE, TIMESTAMP WITHOUT TIME ZONE, TIME WITH TIME ZONE, TIME WITHOUT TIME ZONE |
 
 ## Connect to Snowflake
 
@@ -227,7 +232,6 @@ data_source orders:
     password: "abc123"
     account: sodadatapartner.eu-central-1
     database: SNOWFLAKE_SAMPLE_DATA
-    schema: PUBLIC
     warehouse:
     connection_timeout:
     role: PUBLIC
@@ -235,27 +239,27 @@ data_source orders:
     session_parameters:
       QUERY_TAG: soda-queries
       QUOTED_IDENTIFIERS_IGNORE_CASE: false
+  schema: public
 ```
 
-| Property | Required | Notes |
-| --------  | -------- | -----|
-| type  | required |  The name of your Snowflake virtual data source. |
-| username | required | Use environment variables to retrieve this value securely using, for example, `${SNOWFLAKE_USER}`. |
-| password | required | Use environment variables to retrieve this value securely using, for example, `${SNOWFLAKE_PASSWORD}`. |
-| account | required | Use environment variables to retrieve this value securely using, for example, `${SNOWFLAKE_ACCOUNT}`.  |
-| database | required |  |
-| schema | required |  |
-| warehouse | required |   |
-| connection_timeout | required |   |
-| role | optional | See <a href="https://docs.snowflake.com/en/user-guide/security-access-control-overview.html#system-defined-roles" target="_blank">Snowflake System-Defined Roles</a> for details.|
-| QUERY_TAG | optional | See <a href="https://docs.snowflake.com/en/sql-reference/parameters.html#query-tag" target="_blank">QUERY_TAG</a> in Snowflake documentation. |
+| Property                       | Required | Notes                                                                                                                                                                                   |
+| ------------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| type                           | required | The name of your Snowflake virtual data source.                                                                                                                                         |
+| username                       | required | Use environment variables to retrieve this value securely using, for example, `${SNOWFLAKE_USER}`.                                                                                      |
+| password                       | required | Use environment variables to retrieve this value securely using, for example, `${SNOWFLAKE_PASSWORD}`.                                                                                  |
+| account                        | required | Use environment variables to retrieve this value securely using, for example, `${SNOWFLAKE_ACCOUNT}`.                                                                                   |
+| database                       | required |                                                                                                                                                                                         |
+| schema                         | required |                                                                                                                                                                                         |
+| warehouse                      | required |                                                                                                                                                                                         |
+| connection_timeout             | required |                                                                                                                                                                                         |
+| role                           | optional | See <a href="https://docs.snowflake.com/en/user-guide/security-access-control-overview.html#system-defined-roles" target="_blank">Snowflake System-Defined Roles</a> for details.       |
+| QUERY_TAG                      | optional | See <a href="https://docs.snowflake.com/en/sql-reference/parameters.html#query-tag" target="_blank">QUERY_TAG</a> in Snowflake documentation.                                           |
 | QUOTED_IDENTIFIERS_IGNORE_CASE | optional | See <a href="https://docs.snowflake.com/en/sql-reference/parameters.html#quoted-identifiers-ignore-case" target="_blank">QUOTED_IDENTIFIERS_IGNORE_CASE</a> in Snowflake documentation. |
-
 
 ### Supported data types
 
-| Category | Data type |
-| ---- | --------- |
-| text | CHAR, VARCHAR, CHARACTER, STRING, TEXT |
-| number | NUMBER, INT, INTEGER, BIGINT, SMALLINT, TINYINT, BYTEINT, FLOAT, FLOAT4, FLOAT8, DOUBLE, DOUBLE PRECISION, REAL |
-| time | DATE, DATETIME, TIME, TIMESTAMP, TIMESTAMPT_LTZ, TIMESTAMP_NTZ, TIMESTAMP_TZ |
+| Category | Data type                                                                                                       |
+| -------- | --------------------------------------------------------------------------------------------------------------- |
+| text     | CHAR, VARCHAR, CHARACTER, STRING, TEXT                                                                          |
+| number   | NUMBER, INT, INTEGER, BIGINT, SMALLINT, TINYINT, BYTEINT, FLOAT, FLOAT4, FLOAT8, DOUBLE, DOUBLE PRECISION, REAL |
+| time     | DATE, DATETIME, TIME, TIMESTAMP, TIMESTAMPT_LTZ, TIMESTAMP_NTZ, TIMESTAMP_TZ                                    |

--- a/soda-core/configuration.md
+++ b/soda-core/configuration.md
@@ -9,8 +9,8 @@ parent: Soda Core
 
 After you [install Soda Core]({% link soda-core/installation.md %}), you must create files and configure a few settings before you can run a scan.
 
-* Create a **configuration YAML file** to provide details for Soda Core to connect your data source (except Apache Spark DataFrames, which does not use a configuration YAML file).
-* Create a **checks YAML file** to define your Soda Checks for data quality.
+- Create a **configuration YAML file** to provide details for Soda Core to connect your data source (except Apache Spark DataFrames, which does not use a configuration YAML file).
+- Create a **checks YAML file** to define your Soda Checks for data quality.
 
 [Configuration instructions](#configuration-instructions) <br />
 [Connect to Amazon Athena](#connect-to-amazon-athena)<br />
@@ -23,45 +23,51 @@ After you [install Soda Core]({% link soda-core/installation.md %}), you must cr
 
 ## Configuration instructions
 
-Consider following the [Quick start for Soda Core and Soda Cloud]({% link soda/quick-start-soda-core.md %}) that guides you through the steps to configure Soda Core and run a scan of your data. 
+Consider following the [Quick start for Soda Core and Soda Cloud]({% link soda/quick-start-soda-core.md %}) that guides you through the steps to configure Soda Core and run a scan of your data.
 
-1. Soda Core connects with Spark DataFrames in a unique way, using programmtic scans. 
-* If you are using Spark DataFrames, follow the configuration details in [Connect to Apache Spark DataFrames](#connect-to-apache-spark-dataframes), then skip to step 6 to create your checks YAML file.
-* If not, continue to step 2.
+1. Soda Core connects with Spark DataFrames in a unique way, using programmtic scans.
+
+- If you are using Spark DataFrames, follow the configuration details in [Connect to Apache Spark DataFrames](#connect-to-apache-spark-dataframes), then skip to step 6 to create your checks YAML file.
+- If not, continue to step 2.
+
 2. Create a directory in your environment in which to store your configuration and checks YAML files.
-3. In your code editor, create a new YAML file named `configuration.yml` and save it in the directory you just created. 
-4. The configuration YAML file stores connection details for your data source. Use the data source-specific sections below to copy+paste the connection syntax into your file, then adjust the values to correspond with your data source's details. <br/> 
-The following is an example of the connection details Soda Core requires to connect to a PostgreSQL data source. 
+3. In your code editor, create a new YAML file named `configuration.yml` and save it in the directory you just created.
+4. The configuration YAML file stores connection details for your data source. Use the data source-specific sections below to copy+paste the connection syntax into your file, then adjust the values to correspond with your data source's details. <br/>
+   The following is an example of the connection details Soda Core requires to connect to a PostgreSQL data source.
+
 ```yaml
 data_source postgres_retail:
   type: postgres
   connection:
     host: db
-    port: '5432'
+    port: "5432"
     username: postgres
     password: secret
-  database: postgres
+    database: postgres
   schema: public
 ```
+
 5. Save the `configuration.yml` file, then create another new YAML file named `checks.yml` and save it the directory you created.
 6. A Soda Check is a test that Soda Core performs when it scans a dataset in your data source. The checks YAML file stores the Soda Checks you write using [SodaCL]({% link soda-cl/soda-cl-overview.md %}). Copy+paste the following basic check syntax in your file, then adjust the value for `dataset_name` to correspond with the name of one of the datasets in your data source.
+
 ```yaml
 checks for dataset_name:
   - row_count > 0
 ```
-7. Save the changes to the `checks.yml` file. 
+
+7. Save the changes to the `checks.yml` file.
 
 <br />
 
 {% include core-datasource-config.md %}
 
-
 ## Go further
 
-* Next: [Run a scan]({% link soda-core/scan-core.md %}) of the data in your data source.
-* Consider completing the [Quick start for SodaCL]({% link soda/quick-start-sodacl.md %}) to learn how to write more checks for data quality.
-* Need help? Join the <a href="http://community.soda.io/slack" target="_blank"> Soda community on Slack</a>.
-<br />
+- Next: [Run a scan]({% link soda-core/scan-core.md %}) of the data in your data source.
+- Consider completing the [Quick start for SodaCL]({% link soda/quick-start-sodacl.md %}) to learn how to write more checks for data quality.
+- Need help? Join the <a href="http://community.soda.io/slack" target="_blank"> Soda community on Slack</a>.
+  <br />
 
 ---
+
 {% include docs-footer.md %}


### PR DESCRIPTION
Connection snippets were inconsistent with the implementation of parsing of the `database` and `schema` fields (see: https://github.com/sodadata/soda-core/blob/main/soda/core/soda/execution/data_source.py#L123-L124).

My IDE has a markdown formatter that seems to have wanted to clean up some things. Sorry about that it's applied on save. It doesn't seem to break any of the rendering, but if you're not comfortable with this much changes I can go back and undo them all one by one.