### PR TITLE
Fix Soda Agent test deployment nybusbreakdowns

### DIFF
--- a/soda-agent/test-deploy.md
+++ b/soda-agent/test-deploy.md
@@ -117,19 +117,38 @@ If you wish to try creating a new data source in Soda Cloud using the agent you 
 1. From the command-line, create the data source as a pod on your local cluster.
 ```shell
 cat <<EOF | kubectl apply -n soda-agent -f -
+---
 apiVersion: v1
 kind: Pod
 metadata:
   name: nybusbreakdowns
   labels:
-       app: nycbusbreakdowns
-       eks.amazonaws.com/fargate-profile: soda-agent-profile
+    app: nybusbreakdowns
 spec:
   containers:
   - image: sodadata/nybusbreakdowns
-       imagePullPolicy: IfNotPresent
-       name: nybusbreakdowns
+    imagePullPolicy: IfNotPresent
+    name: nybusbreakdowns
+    ports:
+    - name: tcp-postgresql
+      containerPort: 5432
   restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: nybusbreakdowns
+  name: nybusbreakdowns
+spec:
+  ports:
+  - name: tcp-postgresql
+    port: 5432
+    protocol: TCP
+    targetPort: tcp-postgresql
+  selector:
+    app: nybusbreakdowns
+  type: ClusterIP
 EOF
 ```
 2. Once the pod is running, you can use the following configuration details when you add a data source in Soda Cloud, in step 2, **Connect the Data Source**.


### PR DESCRIPTION
This fixes the Soda Agent test deployment by providing a Kubernetes services through which the Soda Agent deployment can connect to the nybusbreakdowns warehouse.

Note: Since we are in this example not running in a EKS fargate cluster the annotation:
```
eks.amazonaws.com/fargate-profile: soda-agent-profile
```
can be removed.