### PR TITLE
add more info about metrics derived by profiling and discovery

### DIFF
--- a/soda-cl/profile.md
+++ b/soda-cl/profile.md
@@ -35,6 +35,7 @@ profile columns:
 [Limitations and known issues](#limitations-and-known-issues)<br />
 [Define dataset discovery](#define-dataset-discovery) <br />
 [Define column profiling](#define-column-profiling)<br />
+[Compute consumption and cost considerations](#compute-consumption-and-cost-considerations)<br />
 [Optional check configurations](#optional-check-configurations) <br />
 [Inclusion and exclusion rules](#inclusion-and-exclusion-rules)<br />
 [Go further](#go-further) <br />
@@ -74,13 +75,15 @@ Reference the [section below](#define-an-automated-monitoring-check) for how to 
 
 ## Limitations and known issues
 
-* *Known issue:* Currently, SodaCL *does not* support column exclusion for the column profiling and dataset discovery configurations when connecting to a Spark DataFrame data source (`soda-core-spark-df`).
-* Soda can only profile columns that contain numbers or text type data; it cannot profile columns that contain time or date data.
+* **Known issue:** Currently, SodaCL *does not* support column exclusion for the column profiling and dataset discovery configurations when connecting to a Spark DataFrame data source (`soda-core-spark-df`).
+* **Data type**: Soda can only profile columns that contain NUMBERS or TEXT type data; it cannot profile columns that contain TIME or DATE data.
+* **Performance:** Both column profiling and dataset discovery can lead to increased computation costs on your datasources. Consider adding these configurations to a selected few datasets to keep costs low. See [Compute consumption and cost considerations](#compute-consumption-and-cost-considerations) for more detail.
+
 
 ## Define dataset discovery  
 <!--Linked to UI, access Shlink-->
 
-Dataset discovery captures basic information about each dataset, including a dataset's schema and the columns it contains.
+Dataset discovery captures basic information about each dataset, including a dataset's schema and the columns it contains. Dataset discovery can be resource-heavy, so carefully consider the datasets about which you truly need information. Refer to [Compute consumption and cost considerations](#compute-consumption-and-cost-considerations) for more detail.
 
 This configuration is limited in its syntax variation, with only a couple of mutable parts to specify the datasets from which to gather and send sample rows to Soda Cloud.
 
@@ -129,7 +132,7 @@ discover datasets:
 ## Define column profiling  
 <!--Linked to UI, access Shlink-->
 
-Column profile information includes details such as the calculated mean value of data in a column, the maximum and minimum values in a column, and the number of rows with missing data. Column profiling can be resource-heavy, so carefully consider the datasets for which you truly need column profile information. 
+Column profile information includes details such as the calculated mean value of data in a column, the maximum and minimum values in a column, and the number of rows with missing data. Column profiling can be resource-heavy, so carefully consider the datasets for which you truly need column profile information. Refer to [Compute consumption and cost considerations](#compute-consumption-and-cost-considerations) for more detail.
 
 This configuration is limited in its syntax variation, with only a couple of mutable parts to specify the datasets from which to gather and send sample rows to Soda Cloud.
 
@@ -175,6 +178,42 @@ profile columns:
 
 ![profile columns](../assets/images/profile-columns.png)
 
+## Compute consumption and cost considerations
+
+Both column profiling and dataset discovery can lead to increased computation costs on your datasources. Consider adding these configurations to a selected few datasets to keep costs low. 
+
+### Discover Datasets
+
+Besides metadata queries to discover the datasets in a data source and their columns, dataset discovery also derives a row count for each dataset. Depending on your data source and the size of your datasets, this can take considerable compute time. Dataset discovery derives the following metrics:
+
+All columns
+* row count
+
+### Profile Columns
+
+Column profiling aims to issue the most optimized queries for your data source, however, given the nature of the derived metrics, those queries can result in full dataset scans and can be slow and costly on large datasets. Column profiling derives the following metrics:
+
+Numeric Columns
+* minimum value
+* maximum value
+* five smallest values
+* five largest values
+* five most frequent values
+* average
+* sum
+* standard deviation
+* variance
+* count of distinct values
+* count of missing values
+* histogram
+
+Text Columns
+* five most frequent values
+* count of distinct values
+* count of missing values
+* average length
+* minimum length
+* maximum length
 
 
 ## Optional check configurations
@@ -211,36 +250,6 @@ profile columns:
 * If you combine an include config and an exclude config and a dataset or column fits both patterns, Soda excludes the dataset or column from discovery or profiling.
 <!--* If you configured `discover datasets` to exclude a dataset but do not explicitly also exclude its columns in `profile columns`, Soda discovers the dataset and profiles its columns. -->
 
-## Compute Consumption and Cost Considerations
-Both columns profiling and table discovery can lead to increased computation costs on your datasources. Consider adding it to a selected few tables if you want to maintain costs low. We list more details for each type of profiling below.
-### Discover Datasets
-Besides metadata queries to discover datasets and their columns, `discover datasets` also derives a **row count** for each table. Depending on your data source and the size of your tables this can take considerable compute time.
-### Profile Columns
-Column profiling aims to issue the most optimized queries for your data source, however, given the nature of the derived metrics, those queries often cause full table scans and can be slow and costly on large tables.
-
-Column profiling derives the following metrics:
-
-**Numeric Columns**:
-- minimum value
-- maximum value
-- top 5 smallest values
-- top 5 largest values
-- top 5 most frequent values
-- aveage
-- sum
-- standard deviation
-- variance
-- count of distinct values
-- count of missing values
-- histogram
-
-**Text Columns**:
-- top 5 most frequent values
-- count of distinct values
-- count of missing values
-- average length
-- minimum length
-- maximum length
 
 
 ## Go further

--- a/soda-cl/profile.md
+++ b/soda-cl/profile.md
@@ -211,6 +211,38 @@ profile columns:
 * If you combine an include config and an exclude config and a dataset or column fits both patterns, Soda excludes the dataset or column from discovery or profiling.
 <!--* If you configured `discover datasets` to exclude a dataset but do not explicitly also exclude its columns in `profile columns`, Soda discovers the dataset and profiles its columns. -->
 
+## Compute Consumption and Cost Considerations
+Both columns profiling and table discovery can lead to increased computation costs on your datasources. Consider adding it to a selected few tables if you want to maintain costs low. We list more details for each type of profiling below.
+### Discover Datasets
+Besides metadata queries to discover datasets and their columns, `discover datasets` also derives a **row count** for each table. Depending on your data source and the size of your tables this can take considerable compute time.
+### Profile Columns
+Column profiling aims to issue the most optimized queries for your data source, however, given the nature of the derived metrics, those queries often cause full table scans and can be slow and costly on large tables.
+
+Column profiling derives the following metrics:
+
+**Numeric Columns**:
+- minimum value
+- maximum value
+- top 5 smallest values
+- top 5 largest values
+- top 5 most frequent values
+- aveage
+- sum
+- standard deviation
+- variance
+- count of distinct values
+- count of missing values
+- histogram
+
+**Text Columns**:
+- top 5 most frequent values
+- count of distinct values
+- count of missing values
+- average length
+- minimum length
+- maximum length
+
+
 ## Go further
 * Need help? Join the <a href="https://community.soda.io/slack" target="_blank"> Soda community on Slack</a>.
 * Reference [tips and best practices for SodaCL]({% link soda/quick-start-sodacl.md %}#tips-and-best-practices-for-sodacl).

--- a/soda/new-documentation.md
+++ b/soda/new-documentation.md
@@ -9,6 +9,10 @@ parent: Reference
 
 <br />
 
+#### November 16, 2022
+
+* Added content to more explictly describe the metrics that dataset discovery and column profiling derive, and the potential [compute costs]({% link soda-cl/profile.md %}#compute-consumption-and-cost-considerations) associated with these configurations.
+
 #### November 15, 2022
 
 * Added release notes documentation for Soda Core 3.0.13.


### PR DESCRIPTION
It looks like we weren't really giving much information about profiling and discovery runs regarding their computational impact (both internally and externally).

This PR offers more information.

@janet-can I leave it up to you to choose the level of visibility. I've added this kind of at the end, but we may want to have an anchor link somewhere at the top with a warning on consumption. But not sure what's the best approach here so feel free to just take over this branch.