### PR TITLE
add troubleshooting for tbb error on M1 and deprecate some legacy installation troubleshooting

### DIFF
--- a/_includes/troubleshoot-anomaly-check-tbb.md
+++ b/_includes/troubleshoot-anomaly-check-tbb.md
@@ -1,27 +1,24 @@
-Several users have had issues running the `anomaly score` check on M1 MacOS machines and are getting a `Library not loaded: @rpath/libtbb.dylib` error. This issue is well known throughout the community and is due to a few issues during the installation of the [`prophet`](https://github.com/facebook/prophet) library. While there currently are no official workarounds or releases intended to fix the problem from the library we have found that doing the following has proven to help.
+If you have defined an `anomaly score` check and you use an M1 MacOS machine, you may get a`Library not loaded: @rpath/libtbb.dylib` error. This is a known issue in the MacOS community and is caused by issues during the installation of the <a href="https://github.com/facebook/prophet" target="_blank">prophet library</a>. There currently are no official workarounds or releases to fix the problem, but the following adjustments may address the issue.
 
-1. Install soda-core-scientific as you would normally and by following [virtual environment installation instructions](#install-soda-core-scientific-in-a-virtual-environment-recommended)
-2. In a terminal, activate the virtual environment you've just created.
-3. Navigate to the location where the `stan_model` of the `prophet` package is installed in your virtual environment using the following command:
-
-  ```bash
-  cd <path_to_your_python_virtual_env>/lib/python<your_version>/site_packages/prophet/stan_model/
+1. Install soda-core-scientific as per the [virtual environment installation instructions](#install-soda-core-scientific-in-a-virtual-environment-recommended) and activate the virtual environment.
+2. Use the following command to navigate to the directory in which the `stan_model` of the `prophet` package is installed in your virtual environment.
+```shell
+cd path_to_your_python_virtual_env/lib/pythonyour_version/site_packages/prophet/stan_model/
   ```
-
-  For example, if you have created a python virtual environment in a `/venvs` folder in your home folder and used Python 3.9, the command above would look like:
-
-  ```bash
-  cd ~/venvs/soda-core-prophet11/lib/python3.9/site-packages/prophet/stan_model/
+For example, if you have created a python virtual environment in a `/venvs` directory in your home directory and you use Python 3.9, you would use the following command.
+```shell
+cd ~/venvs/soda-core-prophet11/lib/python3.9/site-packages/prophet/stan_model/
   ```
-
-4. Add the `rpath` of the `tbb` library to your `prophet` installation using the following command:
-
-```bash
-install_name_tool -add_rpath @executable_path/cmdstan<your_cmdstan_version>/stan/lib/stan_math/lib/tbb prophet_model.bin
+3. Use the `ls` command to determine the version number of `cmndstan` that `prophet` installed. The `cmndstan` directory name includes the version number.
+```shell
+ls
+cmdstan-2.26.1		prophet_model.bin
 ```
-To find out which version of `cmdstan` was installed by `prophet` doing `ls` in the `stan_model` directory you navigated to in step 4 should display a folder named `cmdstan-<version_number>`. At the time of writing, the installed version is `2.26.1` so we would run:
+4. Add the `rpath` of the `tbb` library to your `prophet` installation using the following command.
+```shell
+install_name_tool -add_rpath @executable_path/cmdstanyour_cmdstan_version/stan/lib/stan_math/lib/tbb prophet_model.bin
+```
+With `cmdstan` version `2.26.1`, you would use the following command.
 ```bash
 install_name_tool -add_rpath @executable_path/cmdstan-2.26.1/stan/lib/stan_math/lib/tbb prophet_model.bin
 ```
-
-5. Use soda-core with an anomaly check as you normally would.

--- a/_includes/troubleshoot-anomaly-check-tbb.md
+++ b/_includes/troubleshoot-anomaly-check-tbb.md
@@ -1,0 +1,27 @@
+Several users have had issues running the `anomaly score` check on M1 MacOS machines and are getting a `Library not loaded: @rpath/libtbb.dylib` error. This issue is well known throughout the community and is due to a few issues during the installation of the [`prophet`](https://github.com/facebook/prophet) library. While there currently are no official workarounds or releases intended to fix the problem from the library we have found that doing the following has proven to help.
+
+1. Install soda-core-scientific as you would normally and by following [virtual environment installation instructions](#install-soda-core-scientific-in-a-virtual-environment-recommended)
+2. In a terminal, activate the virtual environment you've just created.
+3. Navigate to the location where the `stan_model` of the `prophet` package is installed in your virtual environment using the following command:
+
+  ```bash
+  cd <path_to_your_python_virtual_env>/lib/python<your_version>/site_packages/prophet/stan_model/
+  ```
+
+  For example, if you have created a python virtual environment in a `/venvs` folder in your home folder and used Python 3.9, the command above would look like:
+
+  ```bash
+  cd ~/venvs/soda-core-prophet11/lib/python3.9/site-packages/prophet/stan_model/
+  ```
+
+4. Add the `rpath` of the `tbb` library to your `prophet` installation using the following command:
+
+```bash
+install_name_tool -add_rpath @executable_path/cmdstan<your_cmdstan_version>/stan/lib/stan_math/lib/tbb prophet_model.bin
+```
+To find out which version of `cmdstan` was installed by `prophet` doing `ls` in the `stan_model` directory you navigated to in step 4 should display a folder named `cmdstan-<version_number>`. At the time of writing, the installed version is `2.26.1` so we would run:
+```bash
+install_name_tool -add_rpath @executable_path/cmdstan-2.26.1/stan/lib/stan_math/lib/tbb prophet_model.bin
+```
+
+5. Use soda-core with an anomaly check as you normally would.

--- a/soda-cl/anomaly-score.md
+++ b/soda-cl/anomaly-score.md
@@ -151,6 +151,7 @@ for each dataset T:
 While installing Soda Core Scientific works on Linux, you may encounter issues if you install Soda Core Scientific on Mac OS (particularly, machines with the M1 ARM-based processor) or any other operating system. If that is the case, consider using one of the following alternative installation procedures.
 * [Use Docker to run Soda Core (Recommended)](#use-docker-to-run-soda-core)
 * [Install Soda Core locally (Limited support)](#install-soda-core-locally)
+* [Troubleshoot `Library not loaded: @rpath/libtbb.dylib`]()
 
 Need help? Ask the team in the <a href="https://community.soda.io/slack" target="_blank"> Soda community on Slack</a>.
 
@@ -161,6 +162,10 @@ Need help? Ask the team in the <a href="https://community.soda.io/slack" target=
 ### Install Soda Core Scientific Locally 
 
 {% include install-local-soda-core-scientific.md %}
+
+### Troubleshoot `Library not loaded: @rpath/libtbb.dylib` error message
+
+{% include troubleshoot-anomaly-check-tbb.md %}
 
 
 ## Go further

--- a/soda-cl/anomaly-score.md
+++ b/soda-cl/anomaly-score.md
@@ -151,9 +151,10 @@ for each dataset T:
 While installing Soda Core Scientific works on Linux, you may encounter issues if you install Soda Core Scientific on Mac OS (particularly, machines with the M1 ARM-based processor) or any other operating system. If that is the case, consider using one of the following alternative installation procedures.
 * [Use Docker to run Soda Core (Recommended)](#use-docker-to-run-soda-core)
 * [Install Soda Core locally (Limited support)](#install-soda-core-locally)
-* [Troubleshoot `Library not loaded: @rpath/libtbb.dylib`]()
+* [Troubleshoot Soda Core Scientific installation in a virtual env](#troubleshoot-soda-core-scientific-installation-in-a-virtual-env)
 
 Need help? Ask the team in the <a href="https://community.soda.io/slack" target="_blank"> Soda community on Slack</a>.
+
 
 ### Use Docker to run Soda Core
 
@@ -163,7 +164,7 @@ Need help? Ask the team in the <a href="https://community.soda.io/slack" target=
 
 {% include install-local-soda-core-scientific.md %}
 
-### Troubleshoot `Library not loaded: @rpath/libtbb.dylib` error message
+### Troubleshoot Soda Core Scientific installation in a virtual env
 
 {% include troubleshoot-anomaly-check-tbb.md %}
 

--- a/soda-core/installation.md
+++ b/soda-core/installation.md
@@ -159,6 +159,10 @@ You have three installation options to choose from:
 
 {% include install-soda-core-scientific.md %}
 
+### Troubleshoot `Library not loaded: @rpath/libtbb.dylib` error when running anomaly score check
+
+{% include troubleshoot-anomaly-check-tbb.md %}
+
 ## Use Docker to run Soda Core Scientific
 
 {% include docker-soda-core.md %}

--- a/soda-core/installation.md
+++ b/soda-core/installation.md
@@ -163,11 +163,6 @@ You have three installation options to choose from:
 
 {% include docker-soda-core.md %}
 
-## Install Soda Core Scientific locally
-
-{% include install-local-soda-core-scientific.md %}
-
-
 ## Go further
 
 * Next: [Configure]({% link soda-core/configuration.md %}) your newly-installed Soda Core to connect to your data source.

--- a/soda-core/installation.md
+++ b/soda-core/installation.md
@@ -153,13 +153,14 @@ Install Soda Core Scientific to be able to use SodaCL [distribution checks]({% l
 You have three installation options to choose from:
 * [Install Soda Core Scientific in a virtual environment (Recommended)](#install-soda-core-scientific-in-a-virtual-environment-recommended)
 * [Use Docker to run Soda Core with Soda Scientific](#use-docker-to-run-soda-core-scientific)
-* [Install Soda Core Scientific locally](#install-soda-core-scientific-locally)
 
 ## Install Soda Core Scientific in a virtual environment (Recommended)
 
 {% include install-soda-core-scientific.md %}
 
-### Troubleshoot `Library not loaded: @rpath/libtbb.dylib` error when running anomaly score check
+<br />
+
+#### Error: Library not loaded
 
 {% include troubleshoot-anomaly-check-tbb.md %}
 

--- a/soda/new-documentation.md
+++ b/soda/new-documentation.md
@@ -9,6 +9,10 @@ parent: Reference
 
 <br />
 
+#### November 28, 2022
+
+* Added [troubleshooting insturctions]({% link soda-core/installation.md %}#error-library-not-loaded) for Soda Core Scientific on an M1 MacOS machine.
+
 #### November 23, 2022
 
 * Updated [version compatibility]({% link soda-agent/deploy.md %}#compatibility) for Kubernetes clusters when deploying a Soda Agent. 


### PR DESCRIPTION
- removes the old installation instructions of sci library that were due to legacy prophet
- adds troubleshooting for a new problem with the new prophet on M1s (fun!)