### PR TITLE
Add release notes for 3.0.23 plus misc additions

### DIFF
--- a/_release-notes/soda-core-v3.0.23.md
+++ b/_release-notes/soda-core-v3.0.23.md
@@ -1,0 +1,20 @@
+---
+name: "3.0.23"
+date: 2023-02-16
+products:
+  - soda-core
+---
+
+## Fixes and features
+
+* Core: Optimize duplicate query by @m1n0 in #1781
+* Core: Pin duckdb version by @baturayo in #1791
+* Core: Invalid values/format/regex for validity checks by @m1n0 in #1793
+* Core: Data source utils: support config as string by @m1n0 in #1796
+* Profiling refactor: profiler implementation by @baturayo in #1775
+* Anomaly detection: Fix - confidence bounds of anomaly detection sit too close together by @tituskx in #1780
+* Anomaly detection: Bug - anomaly detection doesn’t use more than 3 historical check results by @baturayo in #1787
+* Cloud: Fix verbose mode in cloud requests by @m1n0 in #1792
+* CI: Update workflow.yml by @vijaykiran in #1794
+
+Refer to the <a href="https://github.com/sodadata/soda-core/releases" target="_blank">Soda Core Release Notes </a> for details.

--- a/soda-cl/check-templates.md
+++ b/soda-cl/check-templates.md
@@ -134,7 +134,7 @@ The first example is a skeletal query into which you can insert a variety of con
 ```yaml
 checks for dim_product:
   - failed rows: 
-      fail expression: not({{ condition_logic }})
+      fail condition: not({{ condition_logic }})
 ```
 {% endraw %}
 
@@ -156,7 +156,7 @@ checks for dim_product:
 ```yaml
 checks for dim_product:
   - failed rows:
-      fail expression: not(credit_card_amount + wire_tranfer = total_order_value)
+      fail condition: not(credit_card_amount + wire_tranfer = total_order_value)
 ```
 {% endraw %}
 
@@ -178,7 +178,7 @@ checks for dim_product:
 ```yaml
 checks for dim_product:
   - failed rows: 
-      fail expression: not(full_payment_deadline < dateadd(month, number_of_installments, first_payment_date))
+      fail condition: not(full_payment_deadline < dateadd(month, number_of_installments, first_payment_date))
 ```
 {% endraw %}
 

--- a/soda-cl/filters.md
+++ b/soda-cl/filters.md
@@ -38,8 +38,10 @@ checks for ${DATASET}:
 [In-check vs. dataset filters](#in-check-vs-dataset-filters)<br />
 [Configure in-check filters](#configure-in-check-filters)<br />
 [Configure dataset filters](#configure-dataset-filters)<br />
+[Configure a time partition using the NOW variable](#configure-a-time-partition-using-the-now-variable)<br />
 [Configure variables in SodaCL](#configure-variables-in-sodacl)<br />
-[Configure variables for connection configuration](#configure-variables-for-connection-configuration)<br />
+&nbsp;&nbsp;&nbsp;&nbsp;[Configure variables for connection configuration](#configure-variables-for-connection-configuration)<br />
+&nbsp;&nbsp;&nbsp;&nbsp;[Configuration details and limitations](#configuration-details-and-limitations)<br />
 [Go further](#go-further)<br />
 <br />
 
@@ -80,6 +82,20 @@ For a dataset filter, Soda Core generates a separate query and, again, attempts 
 ## Configure dataset filters
 
 {% include dataset-filters.md %}
+
+## Configure a time partition using the NOW variable
+
+If your data source is partitioned, or if you wish to apply checks in your [agreement]({% link soda-cloud/agreements.md %}) to a specific interval of time, you can do so using a dataset filter. 
+
+Use the built-in `NOW` variable to specify a relative time partition. Reference the following example to add a dataset filter to either your checks YAML file, or to the **Write Checks** step in the agreement workflow in Soda Cloud. The `where` clause in the example defines the time partition to mean "now, less one day". 
+
+```yaml
+filter sodatest_dataset [daily]:
+  where: ts > TIMESTAMP '${NOW}' - interval '1d'
+
+checks for sodatest_dataset [daily]:
+  - duplicate_count(email_address) < 5
+```
 
 ## Configure variables in SodaCL
 
@@ -180,15 +196,7 @@ checks for dim_product:
 
 <br />
 
-###  Configuration details and limitations
-
-* Variables must use the following syntax: `${VAR_NAME}`.
-* You cannot use a variable to provide a scan-time value for a [configuration key]({% link soda-cl/validity-metrics.md %}#list-of-configuration-keys) value, such as the value for `valid length` for an `invalid_count` check.
-* For consistency, best practice dictates that you use upper case for variable names, though you can use lower case if you wish.
-* You may need to wrap date values for variables in single quotes for a check to execute properly. The use of single quotes is bound to the data source, so if your data source demands single quotes around date values for SQL queries, you must also include them when providing date values in Soda. Refer to the [# Dataset filter with variables](#filters-and-variables) example at the top of this page.  
-
-
-## Configure variables for connection configuration
+### Configure variables for connection configuration
 
 You can use variables to:
 * resolve credentials in configuration files using system variables; see [Configure Soda Core]({% link soda-core/configuration.md %}#provide-credentials-as-system-variables)
@@ -221,8 +229,12 @@ soda scan -d adventureworks -c configuration.yml -v USERNAME=sodacore -v PASSWOR
 
 ###  Configuration details and limitations
 
-* If you do not explicitly specify a variable value at scan time to resolve credentials, Soda uses environment variables.
+* Variables must use the following syntax: `${VAR_NAME}`.
 * For consistency, best practice dictates that you use upper case for variable names, though you can use lower case if you wish.
+* If you do not explicitly specify a variable value at scan time to resolve credentials for a connection configuration, Soda uses environment variables.
+* You cannot use a variable to provide a scan-time value for a [configuration key]({% link soda-cl/validity-metrics.md %}#list-of-configuration-keys) value, such as the value for `valid length` for an `invalid_count` check.
+* You may need to wrap date values for variables in single quotes for a check to execute properly. The use of single quotes is bound to the data source, so if your data source demands single quotes around date values for SQL queries, you must also include them when providing date values in SodaCL. Refer to the [# Dataset filter with variables](#filters-and-variables) example at the top of this page.  
+* Except for using the `${NOW}` variable in a dataset filter to [configure a time partition](#configure-a-time-partition-using-the-now-variable) for checks, you cannot use variables when defining checks in an [agreement]({% link soda-cloud/agreements.md %}) in Soda Cloud. When using variables, you normally pass the values for those variables at scan time, adding them to the `soda scan` command with a `-v` option. However, because scans that execute checks defined in an agreement run on a schedule according to a [scan definition]({% link soda/glossary.md %}#scan-definition), there is no opportunity to add dynamic values for variables at scan time.
 
 
 ## Go further

--- a/soda-cl/troubleshoot.md
+++ b/soda-cl/troubleshoot.md
@@ -8,17 +8,17 @@ parent: SodaCL
 # Troubleshoot SodaCL
 *Last modified on {% last_modified_at %}*
 
-[Errors with invalid format](#errors-with-invalid-format)<br />
+[Errors with valid format](#errors-with-valid-format)<br />
 [Soda does not recognize variables](#soda-does-not-recognize-variables)<br />
 [Missing check results in Soda Cloud](#missing-check-results-in-soda-cloud)<br />
 [Metrics were not computed for check](#metrics-were-not-computed-for-check)<br />
 <br />
 
-## Errors with invalid format
+## Errors with valid format
 
-**Problem:** You have written a check using an `invalid_count` or `invalid_percent` metric and used an `invalid format` config key to specify the values that qualify as invalid, but Soda errors on scan.
+**Problem:** You have written a check using an `invalid_count` or `invalid_percent` metric and used a `valid format` config key to specify the values that qualify as valid, but Soda errors on scan.
 
-**Solution:** The `invalid format` configuration key only works with data type TEXT. See [Specify valid format]({% link soda-cl/validity-metrics.md %}#specify-valid-format).
+**Solution:** The `valid format` configuration key only works with data type TEXT. See [Specify valid format]({% link soda-cl/validity-metrics.md %}#specify-valid-format).
 
 See also: [Tips and best practices for SodaCL]({% link soda/quick-start-sodacl.md %}#tips-and-best-practices-for-sodacl)
 

--- a/soda-cl/validity-metrics.md
+++ b/soda-cl/validity-metrics.md
@@ -12,6 +12,7 @@ Use a validity metric in a check to surface invalid or unexpected values in your
 
 ```yaml
 checks for dim_customer:
+# Check for valid values
   - invalid_count(email_address) = 0:
       valid format: email
   - invalid_percent(english_education) = 0:
@@ -28,10 +29,15 @@ checks for dim_customer:
       valid regex: (0?[0-9]|1[012])[/](0?[0-9]|[12][0-9]|3[01])[/](0000|(19|20)?\d\d)
   - invalid_count(house_owner_flag) = 0:
       valid values: ['0', '1']
+# Check for invalid values
+  - invalid_count(first_name) = 0:
+      invalid values: [Antonio]
+  - invalid_count(number_cars_owned) = 0:
+      invalid values: ['0', '3'] 
 ```
 
 [Define checks with validity metrics](#define-checks-with-validity-metrics) <br />
-&nbsp;&nbsp;&nbsp;&nbsp;[Specify valid values](#specify-valid-values)<br />
+&nbsp;&nbsp;&nbsp;&nbsp;[Specify valid or invalid values](#specify-valid-or-invalid-values)<br />
 &nbsp;&nbsp;&nbsp;&nbsp;[Specify valid format](#specify-valid-format)<br />
 &nbsp;&nbsp;&nbsp;&nbsp;[Failed row samples](#failed-row-samples)<br />
 [Optional check configurations](#optional-check-configurations)<br />
@@ -47,8 +53,8 @@ checks for dim_customer:
 In the context of [SodaCL check types]({% link soda-cl/metrics-and-checks.md %}#check-types), you use validity metrics in standard checks. Refer to [Standard check types]({% link soda-cl/metrics-and-checks.md %}#standard-check-types) for exhaustive configuration details.
 
 You can use all validity metrics in checks that apply to individual columns in a dataset; you cannot use validity metrics in checks that apply to entire datasets. Identify the column by adding a value in the argument between brackets in the check. 
-* You must use a [configuration key:value pair](#list-of-configuration-keys) to define what qualifies as an valid value. 
-* If you wish, you can add a `%` character to the threshold for a `invalid_percent` metric for improved readability. 
+* You must use a [configuration key:value pair](#list-of-configuration-keys) to define what qualifies as an valid value or invalid value. 
+* If you wish, you can add a `%` character to the threshold for a `invalid_percent` metric for improved readability. This character does not behave as a wildard in this context.
 
 
 ```yaml
@@ -92,9 +98,9 @@ Percentage thresholds are between 0 and 100, not between 0 and 1.
 </details>
 
 
-### Specify valid values
+### Specify valid or invalid values
 
-Use a nested **configuration key:value pair** to provide your own definition of a valid value. There are several configuration keys that you can use to define what qualifies as valid; the examples below illustrate the use of just a few config keys. See a complete [List of configuration keys](#list-of-configuration-keys) below.
+Use a nested **configuration key:value pair** to provide your own definition of a valid or invalid value. There are several configuration keys that you can use to define what qualifies as valid; the examples below illustrate the use of just a few config keys. See a complete [List of configuration keys](#list-of-configuration-keys) below.
 
 A check that uses a validity metric has six mutable parts:
 
@@ -138,6 +144,18 @@ Second check:
 | threshold | `0` | 
 | configuration key | `valid regex` |
 | configuration value(s) | `(0?[0-9]|1[012])[/](0?[0-9]|[12][0-9]|3[01])[/](0000|(19|20)?\d\d)` |
+
+<br />
+
+The `invalid values` configuration key specifies that if a row in that column contains the invalid values in the list, Soda registers them as invalid. In the example below, the check fails if Soda discovers any values that are `Antonio`. 
+* Values in a list must be enclosed in square brackets.
+* Numeric characters in an `invalid values` list must be enclosed in single quotes.
+
+```yaml
+checks for dim_customer:
+  - invalid_count(first_name) = 0:
+      invalid values: [Antonio]
+```
 
 <br />
 
@@ -277,8 +295,8 @@ checks for CUSTOMERS [daily]:
 
 | Metric  | Column config keys | Description | Supported data type | Supported data sources | 
 | ------  | ------------------ | ----------- |---------------------| ---------------------- |
-| `invalid_count` | `valid format` <br /> `valid length` <br /> `valid max`<br /> `valid max length`<br /> `valid min` <br /> `valid min length`<br /> `valid regex` <br /> `valid values` | The number of<br /> rows in a<br /> column that<br /> contain values<br /> that are not valid. | number,<br />  text,<br />  time |  Athena <br /> Redshift <br />  Apache Spark DataFrames <br /> Big Query <br /> DB2 <br /> SQL Server <br /> PostgreSQL <br /> Snowflake   |
-| `invalid_percent` | `valid format` <br /> `valid length` <br /> `valid max`<br /> `valid max length`<br /> `valid min` <br /> `valid min length`<br /> `valid regex` <br /> `valid values` | The percentage <br />of rows in a <br />column, relative to the total <br />row count, that <br />contain values <br />that are not <br />valid. | number,<br /> text,<br />  time |  Athena <br /> Redshift <br />  Apache Spark DataFrames <br /> Big Query <br /> DB2 <br /> SQL Server <br /> PostgreSQL <br /> Snowflake  | 
+| `invalid_count` | `valid format` <br /> `valid length` <br /> `valid max`<br /> `valid max length`<br /> `valid min` <br /> `valid min length`<br /> `valid regex` <br /> `valid values` <br /> `invalid values` | The number of<br /> rows in a<br /> column that<br /> contain values<br /> that are not valid. | number,<br />  text,<br />  time |  Athena <br /> Redshift <br />  Apache Spark DataFrames <br /> Big Query <br /> DB2 <br /> SQL Server <br /> PostgreSQL <br /> Snowflake   |
+| `invalid_percent` | `valid format` <br /> `valid length` <br /> `valid max`<br /> `valid max length`<br /> `valid min` <br /> `valid min length`<br /> `valid regex` <br /> `valid values` <br /> `invalid values`| The percentage <br />of rows in a <br />column, relative to the total <br />row count, that <br />contain values <br />that are not <br />valid. | number,<br /> text,<br />  time |  Athena <br /> Redshift <br />  Apache Spark DataFrames <br /> Big Query <br /> DB2 <br /> SQL Server <br /> PostgreSQL <br /> Snowflake  | 
 
 
 ## List of configuration keys
@@ -295,6 +313,7 @@ The column configuration key:value pair defines what SodaCL ought to consider as
 | `valid min length` | Specifies a valid minimum length for a string. <br />Only works with columns that contain data type TEXT. | integer |
 | `valid regex` | Specifies a regular expression to define your own custom valid values. | regex, no forward slash delimiters |
 | `valid values` | Specifies the values that Soda is to consider valid. Numeric characters in a `valid values` list must be enclosed in single quotes.| values in a list |
+| `invalid values` | Specifies the values that Soda is to consider invalid. Numeric characters in a `valid values` list must be enclosed in single quotes.| values in a list |
 
 ## List of valid formats
 

--- a/soda-cloud/agreements.md
+++ b/soda-cloud/agreements.md
@@ -54,7 +54,8 @@ Use [SodaCL]({% link soda-cl/soda-cl-overview.md %}) to define the checks that S
 
 * For help writing your first checks, consider following the [Quick start for SodaCL]({% link soda/quick-start-sodacl.md %}), including the [Tips and best practices]({% link soda/quick-start-sodacl.md %}#tips-and-best-practices-for-sodacl) section.
 * Avoid using an [anomaly score check]({% link soda-cl/anomaly-score.md %}) to test the agreements workflow. The ML algorithm that anomaly score checks use requires a minimum of four, regular-frequency scans before it has collected enough historic measurements against which to gauge an anomaly. Consider using checks with [numeric]({% link soda-cl/numeric-metrics.md %}), [missing]({% link soda-cl/missing-metrics.md %}), or [validity]({% link soda-cl/validity-metrics.md %}) metrics, instead.
-* Note that any checks you test in the context of this agreements workflow _do not_ appear as "real" check results in the **Check Results** dashboard. 
+* Note that any checks you test in the context of this step in the agreements workflow _do not_ appear as "real" check results in the **Check Results** dashboard. 
+* Do not use variables to define dynamic values in your checks as you cannot provide scan-time values for those variables with scheduled scans. See [Configuration details and limitations]({% link soda-cl/filters.md %}#configuration-details-and-limitations) for details.
 
 <br />
 

--- a/soda/new-documentation.md
+++ b/soda/new-documentation.md
@@ -9,6 +9,10 @@ parent: Reference
 
 <br />
 
+#### February 16, 2023
+* Added documentation for the `invalid values` configuration key. Refer to [Validity metrics]({% link soda-cl/validity-metrics.md %}#list-of-configuration-keys) documentation.
+* Added [release notes]({% link release-notes/soda-core.md %}) documentation for Soda Core 3.0.23.
+
 #### February 10, 2023
 * Added a new section to Distribution check documentation for [defining a sample size]({% link soda-cl/distribution.md %}#define-the-sample-size).
 

--- a/soda/new-documentation.md
+++ b/soda/new-documentation.md
@@ -12,6 +12,7 @@ parent: Reference
 #### February 16, 2023
 * Added documentation for the `invalid values` configuration key. Refer to [Validity metrics]({% link soda-cl/validity-metrics.md %}#list-of-configuration-keys) documentation.
 * Added [release notes]({% link release-notes/soda-core.md %}) documentation for Soda Core 3.0.23.
+* Corrected [custom check templates]({% link soda-cl/check-templates.md %}) to use `fail condition` syntax, not `fail expression`. 
 
 #### February 10, 2023
 * Added a new section to Distribution check documentation for [defining a sample size]({% link soda-cl/distribution.md %}#define-the-sample-size).

--- a/soda/new-documentation.md
+++ b/soda/new-documentation.md
@@ -13,6 +13,8 @@ parent: Reference
 * Added documentation for the `invalid values` configuration key. Refer to [Validity metrics]({% link soda-cl/validity-metrics.md %}#list-of-configuration-keys) documentation.
 * Added [release notes]({% link release-notes/soda-core.md %}) documentation for Soda Core 3.0.23.
 * Corrected [custom check templates]({% link soda-cl/check-templates.md %}) to use `fail condition` syntax, not `fail expression`. 
+* Added instructions to [Configure a time partition using the NOW variable]({% link soda-cl/filters.md %}#configure-a-time-partition-using-the-now-variable).
+* Added a note for limitations on using variables in [checks in agreements]({% link soda-cloud/agreements.md %}#2-write-checks) in Soda Cloud. 
 
 #### February 10, 2023
 * Added a new section to Distribution check documentation for [defining a sample size]({% link soda-cl/distribution.md %}#define-the-sample-size).


### PR DESCRIPTION
- Include `invalid values` config key.
- Corrected syntax for custom check templates.
- Added instructions for using NOW to set time partition in agreements.