### PR TITLE
refactor: remove mention of using dataset names with quotes from `for each` and `sample dataset`

### DIFF
--- a/_includes/foreach-config.md
+++ b/_includes/foreach-config.md
@@ -29,4 +29,5 @@ for each dataset T:
 * Soda Core dataset names matching is case insensitive.
 * If any of your checks specify column names as arguments, make sure the column exists in all datasets listed under the `datasets` heading.
 * To add multiple for each configurations in your checks YAML file, configure another `for each` section header with a different letter identifier, such as `for each dataset R`.
+* For each does not allow you to use quoted dataset names
 

--- a/_includes/foreach-config.md
+++ b/_includes/foreach-config.md
@@ -27,7 +27,8 @@ for each dataset T:
 
 * For each is not compatible with dataset filters.
 * Soda Core dataset names matching is case insensitive.
+* You cannot use quotes around dataset names in a for each configuration.
 * If any of your checks specify column names as arguments, make sure the column exists in all datasets listed under the `datasets` heading.
 * To add multiple for each configurations in your checks YAML file, configure another `for each` section header with a different letter identifier, such as `for each dataset R`.
-* For each does not allow you to use quoted dataset names
+
 

--- a/soda-cl/for-each.md
+++ b/soda-cl/for-each.md
@@ -40,7 +40,7 @@ for each dataset T:
 | ✓ | Add an identity to a check. | [Add a check identity]({% link soda-cl/optional-config.md %}#add-a-check-identity) |
 | ✓ | Define alert configurations to specify warn and fail alert conditions; see [example](#example-with-alert-configuration).| [Add alert configurations]({% link soda-cl/optional-config.md %}#add-alert-configurations). |
 | ✓ | Apply an in-check filter to return results for a specific portion of the data in your dataset; see [example](#example-with-in-check-filer).|  |
-|  | Use quotes when identifying dataset or column names; see [example](#example-with-quotes). <br />Note that the type of quotes you use must match that which your data source uses. For example, BigQuery uses a backtick ({% raw %}`{% endraw %}) as a quotation mark.| [Use quotes in a check]({% link soda-cl/optional-config.md %}#use-quotes-in-a-check) |
+|   | Use quotes when identifying dataset or column names; see [example](#example-with-quotes). <br />Note that the type of quotes you use must match that which your data source uses. For example, BigQuery uses a backtick ({% raw %}`{% endraw %}) as a quotation mark.| [Use quotes in a check]({% link soda-cl/optional-config.md %}#use-quotes-in-a-check) |
 | ✓ | Use wildcard characters ({% raw %} % {% endraw %} in values in the for each configuration; see [example](#example-with-wildcard). | - |
 |   | Apply a dataset filter to partition data during a scan. | - |
 

--- a/soda-cl/for-each.md
+++ b/soda-cl/for-each.md
@@ -39,9 +39,9 @@ for each dataset T:
 | ✓ | Define a name for a for each check; see [example](#example-with-check-name). | [Customize check names]({% link soda-cl/optional-config.md %}#customize-check-names)|
 | ✓ | Add an identity to a check. | [Add a check identity]({% link soda-cl/optional-config.md %}#add-a-check-identity) |
 | ✓ | Define alert configurations to specify warn and fail alert conditions; see [example](#example-with-alert-configuration).| [Add alert configurations]({% link soda-cl/optional-config.md %}#add-alert-configurations). |
-| ✓ | Apply an in-check filter to return results for a specific portion of the data in your dataset; see [example](#example-with-in-check-filer).|  |
-|   | Use quotes when identifying dataset or column names; see [example](#example-with-quotes). <br />Note that the type of quotes you use must match that which your data source uses. For example, BigQuery uses a backtick ({% raw %}`{% endraw %}) as a quotation mark.| [Use quotes in a check]({% link soda-cl/optional-config.md %}#use-quotes-in-a-check) |
-| ✓ | Use wildcard characters ({% raw %} % {% endraw %} in values in the for each configuration; see [example](#example-with-wildcard). | - |
+| ✓ | Apply an in-check filter to return results for a specific portion of the data in your dataset; see [example](#example-with-in-check-filter).| [Add an in-check filter]({% link soda-cl/optional-config.md %}#add-a-filter-to-a-check). |
+|   | Use quotes when identifying dataset or column names. | - |
+| ✓ | Use wildcard characters ({% raw %} % {% endraw %}) in values in the for each configuration; see [example](#example-with-wildcard). | - |
 |   | Apply a dataset filter to partition data during a scan. | - |
 
 

--- a/soda-cl/for-each.md
+++ b/soda-cl/for-each.md
@@ -40,7 +40,7 @@ for each dataset T:
 | ✓ | Add an identity to a check. | [Add a check identity]({% link soda-cl/optional-config.md %}#add-a-check-identity) |
 | ✓ | Define alert configurations to specify warn and fail alert conditions; see [example](#example-with-alert-configuration).| [Add alert configurations]({% link soda-cl/optional-config.md %}#add-alert-configurations). |
 | ✓ | Apply an in-check filter to return results for a specific portion of the data in your dataset; see [example](#example-with-in-check-filer).|  |
-| ✓ | Use quotes when identifying dataset or column names; see [example](#example-with-quotes). <br />Note that the type of quotes you use must match that which your data source uses. For example, BigQuery uses a backtick ({% raw %}`{% endraw %}) as a quotation mark.| [Use quotes in a check]({% link soda-cl/optional-config.md %}#use-quotes-in-a-check) |
+|  | Use quotes when identifying dataset or column names; see [example](#example-with-quotes). <br />Note that the type of quotes you use must match that which your data source uses. For example, BigQuery uses a backtick ({% raw %}`{% endraw %}) as a quotation mark.| [Use quotes in a check]({% link soda-cl/optional-config.md %}#use-quotes-in-a-check) |
 | ✓ | Use wildcard characters ({% raw %} % {% endraw %} in values in the for each configuration; see [example](#example-with-wildcard). | - |
 |   | Apply a dataset filter to partition data during a scan. | - |
 
@@ -83,18 +83,6 @@ for each dataset T:
   checks:
     - max(vacation_hours) < 80:
         filter: sales_territory_key = 11
-```
-
-#### Example with quotes
-
-```yaml
-for each dataset T:
-  datasets:
-    - dim_employee
-    - "dim_customer"
-
-  checks:
-    - row_count > 1
 ```
 
 #### Example with wildcard

--- a/soda-cl/profile.md
+++ b/soda-cl/profile.md
@@ -77,7 +77,7 @@ Reference the [section below](#define-an-automated-monitoring-check) for how to 
 * **Known issue:** Currently, SodaCL *does not* support column exclusion for the column profiling and dataset discovery configurations when connecting to a Spark DataFrame data source (`soda-core-spark-df`).
 * **Data type**: Soda can only profile columns that contain NUMBERS or TEXT type data; it cannot profile columns that contain TIME or DATE data.
 * **Performance:** Both column profiling and dataset discovery can lead to increased computation costs on your datasources. Consider adding these configurations to a selected few datasets to keep costs low. See [Compute consumption and cost considerations](#compute-consumption-and-cost-considerations) for more detail.
-* Neither profiling nor dataset discovery allow you to use quoted dataset names
+* You cannot use quotes around dataset names with either profiling or dataset discovery.
 
 
 ## Define dataset discovery  

--- a/soda-cl/profile.md
+++ b/soda-cl/profile.md
@@ -77,6 +77,7 @@ Reference the [section below](#define-an-automated-monitoring-check) for how to 
 * **Known issue:** Currently, SodaCL *does not* support column exclusion for the column profiling and dataset discovery configurations when connecting to a Spark DataFrame data source (`soda-core-spark-df`).
 * **Data type**: Soda can only profile columns that contain NUMBERS or TEXT type data; it cannot profile columns that contain TIME or DATE data.
 * **Performance:** Both column profiling and dataset discovery can lead to increased computation costs on your datasources. Consider adding these configurations to a selected few datasets to keep costs low. See [Compute consumption and cost considerations](#compute-consumption-and-cost-considerations) for more detail.
+* Neither profiling nor dataset discovery allow you to use quoted table names
 
 
 ## Define dataset discovery  

--- a/soda-cl/profile.md
+++ b/soda-cl/profile.md
@@ -77,7 +77,7 @@ Reference the [section below](#define-an-automated-monitoring-check) for how to 
 * **Known issue:** Currently, SodaCL *does not* support column exclusion for the column profiling and dataset discovery configurations when connecting to a Spark DataFrame data source (`soda-core-spark-df`).
 * **Data type**: Soda can only profile columns that contain NUMBERS or TEXT type data; it cannot profile columns that contain TIME or DATE data.
 * **Performance:** Both column profiling and dataset discovery can lead to increased computation costs on your datasources. Consider adding these configurations to a selected few datasets to keep costs low. See [Compute consumption and cost considerations](#compute-consumption-and-cost-considerations) for more detail.
-* Neither profiling nor dataset discovery allow you to use quoted table names
+* Neither profiling nor dataset discovery allow you to use quoted dataset names
 
 
 ## Define dataset discovery  

--- a/soda-cl/sample-datasets.md
+++ b/soda-cl/sample-datasets.md
@@ -105,18 +105,10 @@ sample datasets:
 |   | Add an identity to a check. |  -  |
 |   | Define alert configurations to specify warn and fail thresholds. | - |
 |   | Apply an in-check filter to return results for a specific portion of the data in your dataset.| - | 
-| ✓ | Use quotes when identifying dataset names; see [example](#example-with-quotes). <br />Note that the type of quotes you use must match that which your data source uses. For example, BigQuery uses a backtick ({% raw %}`{% endraw %}) as a quotation mark. | [Use quotes in a check]({% link soda-cl/optional-config.md %}#use-quotes-in-a-check) |
+|   | Use quotes when identifying dataset names; see [example](#example-with-quotes). <br />Note that the type of quotes you use must match that which your data source uses. For example, BigQuery uses a backtick ({% raw %}`{% endraw %}) as a quotation mark. | [Use quotes in a check]({% link soda-cl/optional-config.md %}#use-quotes-in-a-check) |
 | ✓ | Use wildcard characters ({% raw %} % {% endraw %} with dataset names in the check; see [example](#example-with-wildcards). | - |
 |   | Use for each to apply anomaly score checks to multiple datasets in one scan. | - |
 |   | Apply a dataset filter to partition data during a scan. |  -  |
-
-#### Example with quotes
-
-```yaml
-sample datasets:
-  datasets:
-    - include "prod_customer"
-```
 
 #### Example with wildcards 
 

--- a/soda-cl/sample-datasets.md
+++ b/soda-cl/sample-datasets.md
@@ -105,7 +105,7 @@ sample datasets:
 |   | Add an identity to a check. |  -  |
 |   | Define alert configurations to specify warn and fail thresholds. | - |
 |   | Apply an in-check filter to return results for a specific portion of the data in your dataset.| - | 
-|   | Use quotes when identifying dataset names; see [example](#example-with-quotes). <br />Note that the type of quotes you use must match that which your data source uses. For example, BigQuery uses a backtick ({% raw %}`{% endraw %}) as a quotation mark. | [Use quotes in a check]({% link soda-cl/optional-config.md %}#use-quotes-in-a-check) |
+|   | Use quotes when identifying dataset names. | - |
 | ✓ | Use wildcard characters ({% raw %} % {% endraw %} with dataset names in the check; see [example](#example-with-wildcards). | - |
 |   | Use for each to apply anomaly score checks to multiple datasets in one scan. | - |
 |   | Apply a dataset filter to partition data during a scan. |  -  |

--- a/soda/new-documentation.md
+++ b/soda/new-documentation.md
@@ -9,6 +9,9 @@ parent: Reference
 
 <br />
 
+#### February 21, 2023
+* Revised documentation to clarify that you cannot wrap dataset names in quotes with [profiling or dataset discovery]({% link soda-cl/profile.md %}#limitations-and-known-issues), with [sample collection]({% link soda-cl/sample-datasets.md %}#optional-check-configurations), or in [for each]({% link soda-cl/for-each.md %}#limitations-and-specifics) configurations.
+
 #### February 16, 2023
 * Added documentation for the `invalid values` configuration key. Refer to [Validity metrics]({% link soda-cl/validity-metrics.md %}#list-of-configuration-keys) documentation.
 * Added [release notes]({% link release-notes/soda-core.md %}) documentation for Soda Core 3.0.23.


### PR DESCRIPTION
This PR resolves: [Explain in the docs that we don't support the use of quotes in dataset discovery/profiling/sampling/etc](https://sodadata.atlassian.net/browse/CLOUD-2695)