### PR TITLE
Update cloud release notes

### DIFF
--- a/_release-notes/agents-ga.md
+++ b/_release-notes/agents-ga.md
@@ -1,0 +1,10 @@
+---
+name: "Soda Agents made generally available"
+date: 2023-02-23
+products:
+  - soda-cloud
+---
+
+Soda Agent deployment instructions have been made generally available, no longer in Preview state. See:
+* [Deploy a Soda Agent in Azure AKS]({% link soda-agent/deploy-azure.md %})
+* [Deploy a Soda Agent in Google GKE]({% link soda-agent/deploy-google.md %})

--- a/_release-notes/check-attributes.md
+++ b/_release-notes/check-attributes.md
@@ -1,0 +1,10 @@
+---
+name: "Check attributes"
+date: 2023-01-26
+products:
+  - soda-cloud
+---
+
+Soda Cloud added a new feature to define check attributes that your team can apply to checks when they write them in an agreement or in a checks YAML file for Soda Core.
+
+Read more in [Add check attributes]({% link soda-cl/check-attributes.md %}).

--- a/_release-notes/manage-failed-rows.md
+++ b/_release-notes/manage-failed-rows.md
@@ -1,0 +1,10 @@
+---
+name: "Disable or reroute failed row samples"
+date: 2022-12-15
+products:
+  - soda-cloud
+---
+
+Use these new ways of managing exposure to sensitive data such as personally identifiable information (PII), when collecting failed row samples.
+* Disable failed rows samples for [specific columns]({% link soda-cl/failed-rows-checks.md %}#disable-failed-rows-sampling-for-specific-columns) to effectively “turn off” failed row collection for specific columns in datasets.
+* Reroute any failed rows samples that Soda collects to a secure, internal location rather than Soda Cloud. To do so, add the storage configuration to your [sampler configuration]({% link soda-cl/failed-rows-checks.md %}#reroute-failed-rows-samples) to specify the columns you wish to exclude.

--- a/_release-notes/multiple-owners.md
+++ b/_release-notes/multiple-owners.md
@@ -1,0 +1,8 @@
+---
+name: "Multiple owners of agreements"
+date: 2023-01-26
+products:
+  - soda-cloud
+---
+
+For all our Soda Cloud Agreements users, we’ve made it possible to assign [multiple owners to agreements]({% link soda-cloud/agreements.md %}#3-identify-stakeholders).

--- a/_release-notes/notification-rules-ga.md
+++ b/_release-notes/notification-rules-ga.md
@@ -1,0 +1,8 @@
+---
+name: "Notification rules made generally available"
+date: 2022-12-20
+products:
+  - soda-cloud
+---
+
+Soda Cloud notification rules have been made generally available, no longer in Preview state. See [Set notification rules]({% link soda-cloud/notif-rules.md %}).

--- a/_release-notes/reporting-api-v1.md
+++ b/_release-notes/reporting-api-v1.md
@@ -1,0 +1,14 @@
+---
+name: "Reporting API v1 (Preview)"
+date: 2022-12-15
+products:
+  - reporting-api
+---
+
+Released in Preview state, version 1 offers improvements and additions to Soda Cloud’s Reporting API endpoints.
+* Better performance as the API retrieves all of its data from pre-processed and aggregated data sources.
+* “Tests” have been renamed “checks”.
+* Most endpoints now use pagination.
+* A few endpoints have been deprecated, a new one, Incidents, has been added, and some have changed for the better.
+
+Read more in the [Reporting API Changelog and v1 migration guide]({% link api-docs/reporting-api-v1-migration-guide.md %}).

--- a/_release-notes/scheme-property.md
+++ b/_release-notes/scheme-property.md
@@ -1,0 +1,10 @@
+---
+name: "Scheme property for connecting Core to Cloud"
+date: 2023-01-30
+products:
+  - soda-cloud
+---
+
+The connection configuration for connecting Soda Core to Soda Cloud now includes the option to add a scheme property. This property allows you to provide a value for the scheme property to indicate which scheme to use to initialize the URI instance.
+
+Read more in [Connect Soda Cloud to Soda Core]({% link soda-core/connect-core-to-cloud.md %}#connect).


### PR DESCRIPTION
Starting from 15 December 2002 with [soda-cloud] Disable or reroute failed row samples.