### PR TITLE
refactor: add in-check filter support to configuration

### DIFF
--- a/soda-cl/anomaly-score.md
+++ b/soda-cl/anomaly-score.md
@@ -114,7 +114,7 @@ Consider using the Soda Core Python library to set up a [programmatic scan]({% l
 | ✓ | Define a name for an anomaly score check. |  - |
 | ✓ | Add an identity to a check. | [Add a check identity]({% link soda-cl/optional-config.md %}#add-a-check-identity) |
 |   | Define alert configurations to specify warn and fail thresholds. | - |
-| ✓ | Apply an in-check filter to return results for a specific portion of the data in your dataset.| - | 
+| ✓ | Apply an in-check filter to return results for a specific portion of the data in your dataset; see [example](#example-with-filter). | [Add an in-check filter to a check]({% link soda-cl/optional-config.md %} #add-a-filter-to-a-check) | 
 | ✓ | Use quotes when identifying dataset names; see [example](#example-with-quotes). <br />Note that the type of quotes you use must match that which your data source uses. For example, BigQuery uses a backtick ({% raw %}`{% endraw %}) as a quotation mark. | [Use quotes in a check]({% link soda-cl/optional-config.md %}#use-quotes-in-a-check) |
 |   | Use wildcard characters ({% raw %} % {% endraw %} or {% raw %} * {% endraw %}) in values in the check. |  - |
 | ✓ | Use for each to apply anomaly score checks to multiple datasets in one scan; see [example](#example-with-for-each-checks). | [Apply checks to multiple datasets]({% link soda-cl/optional-config.md %}#apply-checks-to-multiple-datasets) |

--- a/soda-cl/anomaly-score.md
+++ b/soda-cl/anomaly-score.md
@@ -114,7 +114,7 @@ Consider using the Soda Core Python library to set up a [programmatic scan]({% l
 | ✓ | Define a name for an anomaly score check. |  - |
 | ✓ | Add an identity to a check. | [Add a check identity]({% link soda-cl/optional-config.md %}#add-a-check-identity) |
 |   | Define alert configurations to specify warn and fail thresholds. | - |
-|   | Apply an in-check filter to return results for a specific portion of the data in your dataset.| - | 
+| ✓ | Apply an in-check filter to return results for a specific portion of the data in your dataset.| - | 
 | ✓ | Use quotes when identifying dataset names; see [example](#example-with-quotes). <br />Note that the type of quotes you use must match that which your data source uses. For example, BigQuery uses a backtick ({% raw %}`{% endraw %}) as a quotation mark. | [Use quotes in a check]({% link soda-cl/optional-config.md %}#use-quotes-in-a-check) |
 |   | Use wildcard characters ({% raw %} % {% endraw %} or {% raw %} * {% endraw %}) in values in the check. |  - |
 | ✓ | Use for each to apply anomaly score checks to multiple datasets in one scan; see [example](#example-with-for-each-checks). | [Apply checks to multiple datasets]({% link soda-cl/optional-config.md %}#apply-checks-to-multiple-datasets) |


### PR DESCRIPTION
Hey @janet-can it seems that in-check filters are supported for anomaly detection so I adjusted the support for optional configurations section.

Running
```
checks for dim_customer:
  - anomaly score for row_count < default:
        filter: number_cars_owned = 0
```
with 
```
soda scan checks.yaml -c configuration.yaml -d adventureworks --verbose
```
shows the following query
```
...
 {
      "level": "debug",
      "message": "Query adventureworks.dim_customer.aggregation[0]:\nSELECT \n  COUNT(CASE WHEN number_cars_owned = 0 THEN 1 END) \nFROM dim_customer",
      "timestamp": "2023-05-03T14:50:20+00:00",
      "index": 6
    },
...
```
suggesting that the filter is included