### PR TITLE
Custom sampler addition; change to agreement

### DIFF
--- a/soda-cloud/agreements.md
+++ b/soda-cloud/agreements.md
@@ -66,7 +66,7 @@ Use [SodaCL]({% link soda-cl/soda-cl-overview.md %}) to define the checks that S
 
 Add Stakeholders to this agreement who have an interest in maintaining or using the good-quality data in this data source. Consider adding a co-owner to your agreement for redundancy should you, as the agreement author, be absent.
 
-Soda Cloud sends emails to request review and approval from all stakeholders, but does not prevent Soda Cloud from running scans and executing checks in the agreement if not all stakeholders have approved the agreement.
+Soda Cloud sends emails to request review and approval from all stakeholders, and waits to run scans which execute checks in the agreement until all stakeholders have approved the agreement.
 
 <br />
 

--- a/soda-library/programmatic.md
+++ b/soda-library/programmatic.md
@@ -187,22 +187,6 @@ if __name__ == '__main__':
     print(s.get_logs_text())
 ```
 
-Some users have reported success using the custom sampler to write output to a JSON file, as in the following example that sends only failed row samples to a file.
-
-```python
-...
-        # Check SampleContext for more details that you can extract.
-        # print(sample_context.sample.get_schema())
-        if len(rows) > 0:
-        print(name, query, rows)
-        with open(f"{root_dir}/logs/sodacore_failed_records.json", "a") as file:
-            file.write('"check_name": ' + name + "\n")
-            file.write('"query": \n' + query + "\n")
-            file.write(json.dumps(rows, default=str, indent=1))
-            file.write("\n")
-...
-```
-
 
 ### Save failed row samples to an alternate destination
 

--- a/soda-library/programmatic.md
+++ b/soda-library/programmatic.md
@@ -187,6 +187,23 @@ if __name__ == '__main__':
     print(s.get_logs_text())
 ```
 
+Some users have reported success using the custom sampler to write output to a JSON file, as in the following example that sends only failed row samples to a file.
+
+```python
+...
+        # Check SampleContext for more details that you can extract.
+        # print(sample_context.sample.get_schema())
+        if len(rows) > 0:
+        print(name, query, rows)
+        with open(f"{root_dir}/logs/sodacore_failed_records.json", "a") as file:
+            file.write('"check_name": ' + name + "\n")
+            file.write('"query": \n' + query + "\n")
+            file.write(json.dumps(rows, default=str, indent=1))
+            file.write("\n")
+...
+```
+
+
 ### Save failed row samples to an alternate destination
 
 If you prefer to send the output of the failed row sampler to a destination other than Soda Cloud, you can do so by customizing the sampler as above, then using the Python API to save the rows to a JSON file. Refer to <a href="https://docs.python.org/3/tutorial/inputoutput.html#reading-and-writing-files" target="_blank">docs.python.org</a> for details.

--- a/soda/new-documentation.md
+++ b/soda/new-documentation.md
@@ -10,7 +10,6 @@ parent: Reference
 <br />
 
 #### August 23, 2023
-* Updated documentation for [custom sampler]({% link soda-library/programmatic.md %}#configure-a-failed-row-sampler) for failed rows collection.
 * Update agreement documentation to reflect the [change in behaviour]({% link soda-cloud/agreements.md %}#3-identify-stakeholders) where scans do not run until stakeholders have approved of the agreement.
 
 #### August 21, 2023

--- a/soda/new-documentation.md
+++ b/soda/new-documentation.md
@@ -9,6 +9,10 @@ parent: Reference
 
 <br />
 
+#### August 23, 2023
+* Updated documentation for [custom sampler]({% link soda-library/programmatic.md %}#configure-a-failed-row-sampler) for failed rows collection.
+* Update agreement documentation to reflect the [change in behaviour]({% link soda-cloud/agreements.md %}#3-identify-stakeholders) where scans do not run until stakeholders have approved of the agreement.
+
 #### August 21, 2023
 * Removed "What the Action does" section from [Integrate Soda with a GitHub Workflow]({% link soda/integrate-github.md %}).
 


### PR DESCRIPTION
Per [thread in community](https://soda-community.slack.com/archives/C038FFU79J5/p1692747409287309), add to custom sampler to print failed rows to JSON file.

Update agreement doc- agreement scans run only after stakeholder approval.