### PR TITLE
Add exit code 4 explanation 

### DIFF
--- a/soda-library/programmatic.md
+++ b/soda-library/programmatic.md
@@ -177,7 +177,8 @@ Soda Library's scan output includes an exit code which indicates the outcome of 
 | 0 | all checks passed, all good from both runtime and Soda perspective |
 | 1 | Soda issues a warning on a check(s) |
 | 2 | Soda issues a failure on a check(s) |
-| 3 | Soda encountered a runtime issue |
+| 3 | Soda encountered a runtime issue, and was able to submit scan results to Soda Cloud |
+| 4 | Soda encountered a runtime issue, but was not able to submit any results to Soda Cloud |
 
 To obtain the exit code, you can add the following to your programmatic scan.
 {% include code-header.html %}


### PR DESCRIPTION
[CLOUD-6156] We've added an extra "official exit code" which we improves the communication between _Soda Library <> Agent <> Cloud_.  We have started referring to this section in the docs from within our code, so I added a small explanation about the exit code in the docs as well.

Tl;Dr:
- exit code `3` is used for "operational errors", but only when those have been pushed to Soda Cloud (so you can see the Scan and its logs in Soda Cloud)
- exit code `4` is also used for "operational errors", but is returned when the "scan results" have not been uploaded to Soda Cloud.  In this case a user can't go into soda cloud to debug the problem and instead has to rely on its own logs (or agent logs)

As always feel free to rewrite.

[CLOUD-6156]: https://sodadata.atlassian.net/browse/CLOUD-6156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ