### PR TITLE
[CLOUD-6169] adjust check licensing count

### DIFF
--- a/soda/active-check.md
+++ b/soda/active-check.md
@@ -105,15 +105,6 @@ checks for fact_internet_sales:
             name: Average discount percentage is less than 40% (grouped-by sales territory)
 ```
 
-<br />
-Using Soda Library CLI, you have the option of running the scan locally, which is to say that Soda Library prints results in the command-line, but does not push results to Soda Cloud. As the scan executed the check, the check counts as active. The following example has one check which counts as active when you run the scan command below it. See also: [Add scan options]({% link soda-library/run-a-scan.md %}#add-scan-options)
-```yaml
-checks for dim_customer:
-    - row_count > 0
-```
-```shell
-soda scan -d adventureworks -c configuration.yml --local checks.yml
-```
 
 ## Go further
 


### PR DESCRIPTION
Closes [CLOUD-6169]  by aligning the documentation with the implementation, which is also changed to make "Active Checks" easier to understand.  (Simplification of approach: WYSIWYG, which means Active Checks basically represents the "Checks" page in an organisation, regardless of history, removal, local runs, etc) 

[CLOUD-6169]: https://sodadata.atlassian.net/browse/CLOUD-6169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ