### PR TITLE
bugfix: fix links in API docs for conflicting paths for REST operations

### DIFF
--- a/api-docs/openapi_backend_publicapi_v1.yaml
+++ b/api-docs/openapi_backend_publicapi_v1.yaml
@@ -464,7 +464,7 @@ paths:
         ## Rate limiting
 
         10 requests/60 seconds
-      operationId: /api/v1/checks
+      operationId: GET/api/v1/checks
       parameters:
         - in: query
           name: datasetId
@@ -560,7 +560,7 @@ paths:
         ## Rate limiting
 
         10 requests/60 seconds
-      operationId: /api/v1/datasets
+      operationId: GET/api/v1/datasets
       parameters:
         - in: query
           name: from
@@ -654,7 +654,7 @@ paths:
         ## Rate limiting
 
         10 requests/60 seconds
-      operationId: /api/v1/scans
+      operationId: POST/api/v1/scans
       requestBody:
         content:
           application/x-www-form-urlencoded:
@@ -747,7 +747,7 @@ paths:
         ## Rate limiting
 
         10 requests/60 seconds
-      operationId: "/api/v1/scans/{scanId}"
+      operationId: "DELETE/api/v1/scans/{scanId}"
       parameters:
         - in: path
           name: scanId
@@ -855,7 +855,7 @@ paths:
         ## Rate limiting
 
         60 requests/60 seconds
-      operationId: "/api/v1/scans/{scanId}"
+      operationId: "GET/api/v1/scans/{scanId}"
       parameters:
         - in: path
           name: scanId
@@ -921,7 +921,7 @@ paths:
 
         - `scanID`: Supply a string value. Use the value of `Location` returned as part of the `201` response when you called the **Trigger a scan** endpoint.
 
-        - `size`: Supply an integer value between 1000 and 1000, inclusive. The default value is 1000.
+        - `size`: Supply an integer value between 100 and 1000, inclusive. The default value is 1000.
 
         - `page`: Supply an integer value. The default value is 0.
 
@@ -944,7 +944,7 @@ paths:
         ## Rate limiting
 
         60 requests/60 seconds
-      operationId: "/api/v1/scans/{scanId}/logs"
+      operationId: "GET/api/v1/scans/{scanId}/logs"
       parameters:
         - in: path
           name: scanId
@@ -1031,7 +1031,7 @@ paths:
         ## Rate limiting
 
         10 requests/10 seconds
-      operationId: /api/v1/test-login
+      operationId: GET/api/v1/test-login
       responses:
         "400":
           content:


### PR DESCRIPTION
Context: 
- https://sodadata.slack.com/archives/C069XA8UHL3/p1708541676081989?thread_ts=1708509863.538619&cid=C069XA8UHL3
- https://sodadata.slack.com/archives/C069XA8UHL3/p1708540306674139