### PR TITLE
Banner for features not supported in soda-core

### DIFF
--- a/_includes/banner-deprecated.md
+++ b/_includes/banner-deprecated.md
@@ -1,5 +1,5 @@
 <div class="info">
   <span class="closebtn" onclick="this.parentElement.style.display='none';">&times;</span>
-  ⚠️ The anomaly score check is deprecated, replaced by <a href="https://docs.soda.io/soda-cl/anomaly-detection.html">anomaly detection check</a>. <br /><br />
-  Existing anomaly score checks continue to function, though Soda recommends you replace anomaly score with anomaly detection checks.
+  The anomaly score check is <strong>deprecated</strong>, replaced by <a href="https://docs.soda.io/soda-cl/anomaly-detection.html">anomaly detection check</a>. <br /><br />
+  Existing anomaly score checks continue to function, though Soda recommends you replace anomaly score with anomaly detection checks. <a href="https://docs.soda.io/soda-cl/anomaly-detection.html#migrate-to-anomaly-detection" target="_blank">Learn how</a>
 </div>

--- a/_includes/banner-upgrade.md
+++ b/_includes/banner-upgrade.md
@@ -1,0 +1,5 @@
+<div class="info">
+  <span class="closebtn" onclick="this.parentElement.style.display='none';">&times;</span>
+  This feature is not supported in <strong>Soda Core OSS</strong>.<br />
+  <a href="https://docs.soda.io/soda/upgrade.html#migrate-from-soda-core" target="_blank">Migrate</a> to <strong>Soda Library</strong> in minutes to start using this feature for free with a 45-day trial.
+</div>

--- a/_sass/color_schemes/soda.scss
+++ b/_sass/color_schemes/soda.scss
@@ -903,8 +903,8 @@ body {
 /* The alert message box */
 .alert {
     padding: 20px 20px 20px 20px;
-    background-color: #69EBBC;
-    color: #333;
+    background-color: #f35fdf;
+    color: #ffffff;
     margin-bottom: 15px;
     position: relative;
 }
@@ -912,7 +912,7 @@ body {
 /* The info message box */
 .info {
     padding: 20px 20px 20px 20px;
-    background-color: #F5F5F5;
+    background-color: #F8F9F9;
     color: black;
     margin-bottom: 15px;
     position: relative;

--- a/soda-cl/anomaly-detection.md
+++ b/soda-cl/anomaly-detection.md
@@ -8,6 +8,8 @@ parent: Soda CL reference
 # Anomaly detection checks
 *Last modified on {% last_modified_at %}*
 
+{% include banner-upgrade.md %}
+
 Use an anomaly detection check to automatically discover anomalies in your check metrics. 
 {% include code-header.html %}
 ```yaml
@@ -53,7 +55,7 @@ checks for dim_customer:
 <small>✔️ &nbsp;&nbsp; Requires Soda Core Scientific (included in a Soda Agent)</small><br />
 <small>✖️ &nbsp;&nbsp; Supported in Soda Core</small><br />
 <small>✔️ &nbsp;&nbsp; Supported in Soda Library 1.2.2 or greater + Soda Cloud</small><br />
-<small>✔️ &nbsp;&nbsp; Supported in Soda Cloud Agreements + Soda Agent</small><br />
+<small>✔️ &nbsp;&nbsp; Supported in Soda Cloud Agreements+ Soda Agent</small><br />
 <small>✖️ &nbsp;&nbsp; Supported by SodaGPT</small><br />
 <small>✖️ &nbsp;&nbsp; Available as a no-code check</small>
 

--- a/soda-cl/automated-monitoring.md
+++ b/soda-cl/automated-monitoring.md
@@ -9,6 +9,8 @@ parent: Write SodaCL checks
 <!--Linked to UI, access Shlink-->
 *Last modified on {% last_modified_at %}*
 
+{% include banner-upgrade.md %}
+
 Use automated monitoring checks to instruct Soda to automatically check for row count anomalies and schema changes in a dataset.<br />
 
 {% include code-header.html %}
@@ -22,8 +24,7 @@ automated monitoring:
 <small>✔️ &nbsp;&nbsp; Requires Soda Core Scientific (included in a Soda Agent)</small><br />
 <small>✖️ &nbsp;&nbsp; Supported in Soda Core</small><br />
 <small>✔️ &nbsp;&nbsp; Supported in Soda Library + Soda Cloud</small><br />
-<small>✔️ &nbsp;&nbsp; Supported in Soda Cloud + self-hosted Soda Agent connected to any <br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Soda-supported data source, except Spark, and Dask and Pandas</small><br />
-<small>✔️ &nbsp;&nbsp; Supported in Soda Cloud + Soda-hosted Agent connected to a BigQuery, Databricks SQL, <br /> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;MS SQL Server, MySQL, PostgreSQL, Redshift, or Snowflake data source</small><br />
+<small>✔️ &nbsp;&nbsp; Supported in Soda Cloud Agreements + Soda Agent</small><br />
 <small>✖️ &nbsp;&nbsp; Supported by SodaGPT</small><br />
 <small>✖️ &nbsp;&nbsp; Available as no-code checks</small>
 <br /><br />

--- a/soda-cl/check-template.md
+++ b/soda-cl/check-template.md
@@ -8,6 +8,8 @@ parent: SodaCL reference
 # Check template
 *Last modified on {% last_modified_at %}*
 
+{% include banner-upgrade.md %}
+
 Use a check template to define a reusable, user-defined metric that you can apply to many checks in multiple checks files.
 {% include code-header.html %}
 ```yaml

--- a/soda-cl/group-by.md
+++ b/soda-cl/group-by.md
@@ -8,6 +8,8 @@ parent: SodaCL reference
 # Group by
 *Last modified on {% last_modified_at %}*
 
+{% include banner-upgrade.md %}
+
 Use a group by configuration to collect and present check results by category.
 
 {% include code-header.html %}

--- a/soda-cl/group-evolution.md
+++ b/soda-cl/group-evolution.md
@@ -8,6 +8,8 @@ parent: SodaCL reference
 # Group evolution checks
 *Last modified on {% last_modified_at %}*
 
+{% include banner-upgrade.md %}
+
 Use a group evolution check to validate the presence or absence of a group in a dataset, or to check for changes to groups in a dataset relative to their previous state.
 {% include code-header.html %}
 ```yaml

--- a/soda-cl/numeric-metrics.md
+++ b/soda-cl/numeric-metrics.md
@@ -223,6 +223,8 @@ for each dataset T:
 
 ## Change-over-time thresholds
 
+{% include banner-upgrade.md %}
+
 Numeric metrics can specify a **fixed threshold** which is not relative to any other threshold. `row_count > 0` is an example of a check with a fixed threshold as the threshold value, `0`, is absolute. Refer to [Checks with fixed thresholds]({% link soda-cl/metrics-and-checks.md %}#checks-with-fixed-thresholds) for details.
 
 Only checks that use numeric metrics can specify a **change-over-time threshold**, a value that is relative to a previously-measured, or historic, value. Sometimes referred to as a dynamic threshold or historic metrics, you use these change-over-time thresholds to gauge changes to the same metric over time. Most of the examples below use the `row_count` metric, but you can use any numeric metric in checks that use change-over-time thresholds. 

--- a/soda-cl/recon.md
+++ b/soda-cl/recon.md
@@ -8,6 +8,8 @@ parent: SodaCL reference
 # Reconciliation checks
 *Last modified on {% last_modified_at %}*
 
+{% include banner-upgrade.md %}
+
 Use a reconciliation check to validate that target data matches source data before and/or after migrating between data sources.
 
 For example, if you must migrate data from a MySQL data source to a Snowflake data source, you can use reconciliation checks to make sure the MySQL data appears intact in Snowflake in staging before conducting the migration in production.

--- a/soda-cl/schema.md
+++ b/soda-cl/schema.md
@@ -127,6 +127,9 @@ checks for dim_employee:
 <br />
 
 ## Define schema evolution checks
+
+{% include banner-upgrade.md %}
+
 <small>✖️ &nbsp;&nbsp; Requires Soda Core Scientific (included in a Soda Agent)</small><br />
 <small>✔️ &nbsp;&nbsp; Supported in Soda Core</small><br />
 <small>✔️ &nbsp;&nbsp; Supported in Soda Library + Soda Cloud</small><br />

--- a/soda-library/check-suggestions.md
+++ b/soda-library/check-suggestions.md
@@ -8,8 +8,9 @@ redirect_from:
 ---
 
 # Adopt check suggestions
-
 *Last modified on {% last_modified_at %}*
+
+{% include banner-upgrade.md %}
 
 **Check suggestions** assists Soda users in auto-generating basic data quality checks using the Soda Checks Language (SodaCL), a domain-specific language for data quality testing.
 
@@ -21,7 +22,7 @@ Instead of writing your own data quality checks from scratch, check suggestions 
 <small>✖️ &nbsp;&nbsp; Supported in Soda Core</small><br />
 <small>✔️ &nbsp;&nbsp; Requires Soda Library + Soda Cloud</small><br />
 <small>✔️ &nbsp;&nbsp; Compatible with BigQuery, PostgreSQL, Snowflake data sources</small><br />
-<small>✖️ &nbsp;&nbsp; Supported in Soda Cloud Agreements + Soda Agent</small><br />
+<small>✖️ &nbsp;&nbsp; Supported in Soda Cloud + Soda Agent</small><br />
 <br />
 
 [Compatibility](#compatibility)<br />


### PR DESCRIPTION
Where it was relevant that a migration to soda-library would enable a feature immediately, added a banner with guidance on how to do so.