### PR TITLE
Add cloud egress ip

### DIFF
--- a/soda/data-privacy.md
+++ b/soda/data-privacy.md
@@ -42,7 +42,6 @@ Soda hosts agents in a secure environment in Amazon AWS. As a SOC 2 Type 2 certi
 
 Installed in your environment, you use the Soda Library command-line tools to securely connect to a data source using system variables to store login credentials.
 
-You can connect Soda Library to your Soda Cloud account. To communicate with your data source, Soda Cloud uses a Network Address Translation (NAT) gateway with the IP address 54.78.91.111. You may wish to add this IP address to your data source's allowlist.
 
 ## Sending data to Soda Cloud
 
@@ -58,6 +57,14 @@ Soda Cloud does store the following:
 Where your datasets contain <a href="https://ec.europa.eu/info/law/law-topic/data-protection/reform/rules-business-and-organisations/legal-grounds-processing-data/sensitive-data/what-personal-data-considered-sensitive_en" target="_blank"> sensitive data</a> or private information, you may *not* want to send failed row samples from your data source to Soda Cloud. In such a circumstance, you can [disable the failed row samples feature entirely]({% link soda-cloud/failed-rows.md %}#disable-failed-row-samples) in Soda Cloud. Read more about disabling samples and failed row samples in [Failed rows checks]({% link soda-cl/failed-rows-checks.md %}).
 
 Read more about Soda's <a href="https://www.soda.io/privacy-policy" target="_blank">Privacy Policy</a>. 
+
+## Receiving events from Soda Cloud
+Soda Cloud can be setup to send events to your services using integrations like Soda Webhooks. If your destination services are behind a firewall, you may need to whitelist Soda Cloud's Egress IP addresses to allow communication. The current IP addresses used by Soda Cloud are:
+
+- EU: `54.78.91.111`, `52.49.181.67`
+- US: `34.208.202.240`, `52.35.114.145`
+
+Ensure these addresses are allowed in your firewall settings to avoid any disruptions in receiving events from Soda Cloud.
 
 ## Single sign-on with Soda Cloud
 


### PR DESCRIPTION
Following up on https://sodadata.slack.com/archives/CNPADCAM8/p1726062821863729?thread_ts=1726062452.017789&cid=CNPADCAM8.

Note that these IP addresses are **only for egress traffic** (soda cloud towards a customer), they are not used for incoming traffic (when someone wants to whitelist Soda Cloud to be accessed from within their network). 

They are also not the IP addresses used by the Soda Hosted Agent. Those can be obtained from within the Soda Cloud UI (as the docs on this page already state). 