### PR TITLE
Minor update to Python API page

### DIFF
--- a/_includes/samples-limit-datasource.md
+++ b/_includes/samples-limit-datasource.md
@@ -9,3 +9,11 @@ data_source soda_test:
   sampler:
     samples_limit: 50
 ```
+
+Alternatively, you can set a samples limit for a datasource using the Soda Library like so:
+{% include code-header.html %}
+```python
+from soda.scan import Scan
+scan = Scan()
+scan._configuration.samples_limit = 50
+```

--- a/_includes/samples-limit-datasource.md
+++ b/_includes/samples-limit-datasource.md
@@ -10,7 +10,7 @@ data_source soda_test:
     samples_limit: 50
 ```
 
-Alternatively, you can set a samples limit for a datasource using the Soda Library like so:
+Alternatively, you can set a samples limit for a datasource using the Soda Library by modifying the value of an attribute of the `Scan` class object:
 {% include code-header.html %}
 ```python
 from soda.scan import Scan

--- a/soda-library/python_api.md
+++ b/soda-library/python_api.md
@@ -346,6 +346,20 @@ def get_all_checks_text(self) -> str | None
 ```
 <br/>
 
+## Configuring the Scan by directly modifying its attributes
+
+Configure the (global) samples limit for failed rows sampler. 
+This is useful when scanning Pandas, Dask, or Spark dataframes. 
+```python
+self._configuration.samples_limit: int
+```
+
+Replace the failed rows sampler with a custom sampler. 
+See [Configure a custom sampler]({% link soda-cl/failed-row-samples.md %}#configure-a-python-custom-sampler)
+for instructions about how to define a custom sampler. 
+```python
+self.sampler: Sampler
+```
 
 <!--
 ### Methods for Remote Scans (beta)

--- a/soda-library/python_api.md
+++ b/soda-library/python_api.md
@@ -239,6 +239,32 @@ def get_error_logs_text(self) -> str | None
 ```
 <br/>
 
+Instruct Soda to return a dictionary containing the results of the scan. 
+```python
+def get_scan_results(self) -> dict
+```
+
+The scan results dictionary includes the following keys:
+```
+"definitionName"
+"defaultDataSource"
+"dataTimestamp"
+"scanStartTimestamp"
+"scanEndTimestamp"
+"hasErrors"
+"hasWarnings"
+"hasFailures"
+"metrics"
+"checks"
+"checksMetadata"
+"queries"
+"automatedMonitoringChecks"
+"profiling"
+"metadata"
+"logs"
+```
+<br/>
+
 
 ### Add configurations to handle check results
 
@@ -271,32 +297,6 @@ def has_check_warns(self) -> bool
 Instruct Soda to return a boolean value to indicate that one or more checks executed during the scan resulted in a fail or warn state.
 ```python
 def has_check_warns_or_fails(self) -> bool
-```
-<br/>
-
-Instruct Soda to return a dictionary containing the results of the scan. 
-```python
-def get_scan_results(self) -> dict
-```
-
-The scan results dictionary includes the following keys:
-```
-"definitionName"
-"defaultDataSource"
-"dataTimestamp"
-"scanStartTimestamp"
-"scanEndTimestamp"
-"hasErrors"
-"hasWarnings"
-"hasFailures"
-"metrics"
-"checks"
-"checksMetadata"
-"queries"
-"automatedMonitoringChecks"
-"profiling"
-"metadata"
-"logs"
 ```
 <br/>
 

--- a/soda-library/python_api.md
+++ b/soda-library/python_api.md
@@ -330,7 +330,7 @@ def get_all_checks_text(self) -> str | None
 ```
 <br/>
 
-## Configuring the Scan by directly modifying its attributes
+## Attributes
 
 Configure the (global) samples limit for failed rows sampler. 
 This is useful when scanning Pandas, Dask, or Spark dataframes. 

--- a/soda-library/python_api.md
+++ b/soda-library/python_api.md
@@ -21,6 +21,7 @@ Refer to [Program a scan]({% link soda-library/run-a-scan.md %}#scan-for-data-qu
 [Add optional scan settings](#add-optional-scan-settings)<br />
 [Add configurations to handle scan results](#add-configurations-to-handle-scan-results)<br />
 [Add configurations to handle check results](#add-configurations-to-handle-check-results)<br />
+[Attributes](#attributes)<br />
 <br />
 
 
@@ -178,6 +179,7 @@ Configure Soda to prevent it from sending scan results to Soda Cloud. This is us
 ```python
 def set_is_local(self, local_var: bool = True)
 ```
+<br/>
 
 Configure a scan to have access to custom variables that can be referenced in your SodaCL files.
 `variables` is a dictionary with string keys and string values. 
@@ -337,11 +339,11 @@ def get_all_checks_text(self) -> str | None
 
 ## Attributes
 
-Configure the datasource-level samples limit for the failed rows sampler. 
-This is useful when scanning Pandas, Dask, or Spark dataframes. 
+Configure the datasource-level samples limit for the failed rows sampler. This is useful when scanning Pandas, Dask, or Spark Dataframes. 
 ```python
 self._configuration.samples_limit: int
 ```
+<br/>
 
 Replace the failed rows sampler with a custom sampler. 
 See [Configure a custom sampler]({% link soda-cl/failed-row-samples.md %}#configure-a-python-custom-sampler)

--- a/soda-library/python_api.md
+++ b/soda-library/python_api.md
@@ -337,7 +337,7 @@ def get_all_checks_text(self) -> str | None
 
 ## Attributes
 
-Configure the (global) samples limit for failed rows sampler. 
+Configure the datasource-level samples limit for the failed rows sampler. 
 This is useful when scanning Pandas, Dask, or Spark dataframes. 
 ```python
 self._configuration.samples_limit: int

--- a/soda-library/python_api.md
+++ b/soda-library/python_api.md
@@ -55,7 +55,6 @@ def execute(self) -> int
 ### Provide required scan settings
 
 Specify the datasource on which Soda executes the checks.
-{% include code-header.html %}
 ```python
 def set_data_source_name(self, data_source_name: str)
 ```
@@ -64,7 +63,6 @@ def set_data_source_name(self, data_source_name: str)
 Provide the scan definition name if the scan has been defined in Soda Cloud. By providing this value, Soda correlates subsequent scans from the same pipeline. 
 
 To retrieve this value, navigate to the **Scans** page in Soda Cloud, then select the scan definition you wish to execute remotely and copy the scan name, which is the smaller text under the label. For example, weekday_scan_schedule.
-{% include code-header.html %}
 ```python
 def set_scan_definition_name(self, scan_definition_name: str)
 ```
@@ -73,7 +71,6 @@ def set_scan_definition_name(self, scan_definition_name: str)
 ### Add configurations to a scan
 
 Add data source and Soda Cloud connection configurations from a YAML file. `file_path` is a string that points to a configuration file. `~` expands to the user's home directory.
-{% include code-header.html %}
 ```python
 def add_configuration_yaml_file(self, file_path: str)
 ```
@@ -83,7 +80,6 @@ Optionally, add all connection configurations from all matching YAML files in th
 * `path` is a string that is the path to a directory, but you can use it as a path to a configuration file. `~` expands to the user's home directory or the directory in which to search for configuration files.
 * `recursive` requires a boolean value that controls whether Soda scans nested directories. If unspecified, the default value is `true`.
 * `suffixes` is an optional list of strings that you use when recursively scanning directories to load only those files with a specific extension. If unspecified, the default values are `.yml` and `.yaml`.
-{% include code-header.html %}
 ```python
 def add_configuration_yaml_files(self, path: str, recursive: bool | None = True, suffixes: str | None = None)
 ```
@@ -92,7 +88,6 @@ def add_configuration_yaml_files(self, path: str, recursive: bool | None = True,
 Optionally, add connection configurations from a YAML-formatted string. 
 * `environment_yaml_str` is a string that represents a configuration and must be YAML-formatted.
 * `file_path` is an optional string that you use to get the location of errors in the logs.
-{% include code-header.html %}
 ```python
 def add_configuration_yaml_str(self, environment_yaml_str: str, file_path: str = "yaml string")
 ```
@@ -101,7 +96,6 @@ def add_configuration_yaml_str(self, environment_yaml_str: str, file_path: str =
 ### Add SodaCL checks to a scan
 
 Add a SodaCL checks YAML file to the scan according to a file path you specify. `file_path` is a string that identifies a checks YAML file.
-{% include code-header.html %}
 ```python
 def add_sodacl_yaml_file(self, file_path: str)
 ```
@@ -111,7 +105,6 @@ Optionally, add all the files in a directory to the scan as SodaCL checks YAML f
 * `path` is a string that identifies a directory, but you can use it as a path to a configuration file. `~` expands to the user's home directory or the directory in which to search for checks YAML files.
 * `recursive` is an optional boolean value that controls whether Soda scans nested directories. If unspecified, the default value is `true`.
 * `suffixes` is an optional list of strings that you use when recursively scanning directories to load only those files with a specific extension. If unspecified, the default values are `.yml` and `.yaml`.
-{% include code-header.html %}
 ```python
 def add_sodacl_yaml_files(self, path: str, recursive: bool | None = True, suffixes: list[str] | None = None)
 ```
@@ -120,21 +113,18 @@ def add_sodacl_yaml_files(self, path: str, recursive: bool | None = True, suffix
 Optionally, add SodaCL checks from a YAML-formatted string. 
 * `sodacl_yaml_str` is a string that represents the SodaCL checks and must be YAML-formatted.
 * `file_path` is an optional string that you use to get the location of errors in the logs.
-{% include code-header.html %}
 ```python
 def add_sodacl_yaml_str(self, sodacl_yaml_str: str, file_name: str | None = None):
 ```
 <br/>
 
 If you use a [check template]({% link soda-cl/check-template.md %}) for SodaCL checks, add a SodaCL template file to the scan. `file_path` is a string that identifies a SodaCL template file.
-{% include code-header.html %}
 ```python
 def add_template_file(self, file_path: str)
 ```
 <br/>
 
 If you use multiple [check templates]({% link soda-cl/check-template.md %}) for SodaCL checks, add all the template files in a directory to the scan. `path` is a string that identifies the directory that contains the SodaCL template files.
-{% include code-header.html %}
 ```python
 def add_template_files(self, path: str)
 ```
@@ -146,7 +136,6 @@ If you use Pandas, add a Pandas Dataframe dataset to the scan.
 * `dataset_name` is a string to identify a dataset.
 * `pandas_df` is a Pandas Dataframe object.
 * `data_source_name` is a string to identify a data source.
-{% include code-header.html %}
 ```python
 def add_pandas_dataframe(self, dataset_name: str, pandas_df, data_source_name: str = "dask")
 ```
@@ -156,7 +145,6 @@ If you use Dask, add a Dask Dataframe dataset to the scan.
 * `dataset_name` is a string used to identify a dataset.
 * `dask_df` is a Dask Dataframe object.
 * `data_source_name` is a string to identify a data source.
-{% include code-header.html %}
 ```python
 def add_dask_dataframe(self, dataset_name: str, dask_df, data_source_name: str = "dask")
 ```
@@ -165,7 +153,6 @@ def add_dask_dataframe(self, dataset_name: str, dask_df, data_source_name: str =
 If you use PySpark, add a Spark session to the scan.
 * `spark_session` is a Spark session object.
 * `data_source_name` is a string to identify a data source.
-{% include code-header.html %}
 ```python
 def add_spark_session(self, spark_session, data_source_name: str = "spark_df")
 ```
@@ -174,7 +161,6 @@ def add_spark_session(self, spark_session, data_source_name: str = "spark_df")
 If you use a pre-existing DuckDB connection object as a data source, add a DuckDB connection to the scan. 
 * `duckdb_connection` is a DuckDB connection object.
 * `data_source_name` is a string to identify a data source.
-{% include code-header.html %}
 ```python
 def add_duckdb_connection(self, duckdb_connection, data_source_name: str = "duckdb")
  ```
@@ -183,14 +169,12 @@ def add_duckdb_connection(self, duckdb_connection, data_source_name: str = "duck
 ### Add optional scan settings
 
 Configure a scan to output verbose log information. This is useful when you wish to see the SQL queries that Soda executes or to troubleshoot scan issues.
-{% include code-header.html %}
 ```python
 def set_verbose(self, verbose_var: bool = True)
 ```
 <br/>
 
 Configure Soda to prevent it from sending scan results to Soda Cloud. This is useful if, for example, you are testing checks locally and do not wish to muddy the measurements in your Soda Cloud account with test run metadata.
-{% include code-header.html %}
 ```python
 def set_is_local(self, local_var: bool = True)
 ```

--- a/soda-library/python_api.md
+++ b/soda-library/python_api.md
@@ -179,6 +179,11 @@ Configure Soda to prevent it from sending scan results to Soda Cloud. This is us
 def set_is_local(self, local_var: bool = True)
 ```
 
+Configure a scan to have access to custom variables that can be referenced in your SodaCL files.
+`variables` is a dictionary with string keys and string values. 
+```python
+def add_variables(self, variables: dict[str, str])
+```
 <br/>
 
 ### Add configurations to handle scan results

--- a/soda/new-documentation.md
+++ b/soda/new-documentation.md
@@ -9,6 +9,9 @@ parent: Learning resources
 
 <br /> 
 
+#### October 7, 2024
+* Updated the [Soda Library Python API reference]({% link soda-library/python_api.md %}) documentation with attributes for samples limit, and an optional config for using variables.
+
 #### October 3, 2024
 * Added documentation for using [variables]({% link soda-cl/failed-row-samples.md %}#configure-a-python-custom-sampler) in the `SampleRef` `message` parameter for Python custom sampler to collect and display failed row samples.
 


### PR DESCRIPTION
* Add new "Attributes" section to the Python API reference page
* Add items for `self._configuration.samples_limit` and `self.sampler` under the new "Attributes" section
* Add new method reference to Python API reference page for adding variables to a scan
* Remove code-copy widget from Python API reference code snippets
* Move `get_scan_results` method reference to the section for handling scan results in Python API reference page
* Update samples limit page to include additional method for setting datasource-level samples limits with the Soda Library
