### PR TITLE
Add Soda Agent existing "secrets ref" feature

### DIFF
--- a/soda-agent/secrets.md
+++ b/soda-agent/secrets.md
@@ -255,10 +255,10 @@ soda-agent-secrets   Opaque   1      24h
 <br />
 
 ## Use Soda Cloud API Keys from an existing secret
-By default the Soda Agent will create a secret for storing the Soda Cloud API Key details securely on your cluster.  If you want to manually take control over this secret you can point the Soda Agent to an already existing Kubernetes Secret on your Cluster leveraging the `soda.apikey.existingSecret` property. 
+By default, the Soda Agent creates a secret for storing the Soda Cloud API Key details securely in your cluster.  If you want to use a different secret, you can point the Soda Agent to an existing Kubernetes Secret in your cluster using the `soda.apikey.existingSecret` property. 
 
-To use an existing Kubernetes secret for Soda Agent’s Cloud API credentials, add the following to your deployment values YAML  file:
-
+To use an existing Kubernetes secret for Soda Agent’s Cloud API credentials, add `existingSecret` and the `secretKeys` values to your agent's values YAML file, as in the following example.
+{% include code-header.html %}
 ```yaml
 soda:
   apikey:

--- a/soda-agent/secrets.md
+++ b/soda-agent/secrets.md
@@ -18,6 +18,7 @@ As these values are sensitive, you may wish to employ the following alternative 
 [Use a values file to store private key authentication values](#use-a-values-file-to-store-private-key-authentication-values)<br />
 [Use environment variables to store data source connection credentials](#use-environment-variables-to-store-data-source-connection-credentials)<br />
 [Integrate with a secrets manager](#integrate-with-a-secrets-manager)<br />
+[Use Soda Cloud API Keys from an existing secret](#use-soda-cloud-api-keys-from-an-existing-secret)<br />
 [Go further](#go-further)<br />
 <br />
 
@@ -250,6 +251,23 @@ soda-agent-secrets   Opaque   1      24h
   Check the logs using:
         kubectl logs -l agent.soda.io/component=orchestrator -n soda-agent
    ```
+
+<br />
+
+## Use Soda Cloud API Keys from an existing secret
+By default the Soda Agent will create a secret for storing the Soda Cloud API Key details securely on your cluster.  If you want to manually take control over this secret you can point the Soda Agent to an already existing Kubernetes Secret on your Cluster leveraging the `existingSecret` property. 
+
+To use an existing Kubernetes secret for Soda Agent’s Cloud API credentials, add the following to your deployment values YAML  file:
+
+```yaml
+soda:
+  apikey:
+    existingSecret: "<existing-secret-name>"
+    secretKeys:
+      idKey: "<key-for-api-id>"
+      secretKey: "<key-for-api-secret>"
+```
+
 
 <br />
 

--- a/soda-agent/secrets.md
+++ b/soda-agent/secrets.md
@@ -255,7 +255,7 @@ soda-agent-secrets   Opaque   1      24h
 <br />
 
 ## Use Soda Cloud API Keys from an existing secret
-By default the Soda Agent will create a secret for storing the Soda Cloud API Key details securely on your cluster.  If you want to manually take control over this secret you can point the Soda Agent to an already existing Kubernetes Secret on your Cluster leveraging the `existingSecret` property. 
+By default the Soda Agent will create a secret for storing the Soda Cloud API Key details securely on your cluster.  If you want to manually take control over this secret you can point the Soda Agent to an already existing Kubernetes Secret on your Cluster leveraging the `soda.apikey.existingSecret` property. 
 
 To use an existing Kubernetes secret for Soda Agent’s Cloud API credentials, add the following to your deployment values YAML  file:
 

--- a/soda/new-documentation.md
+++ b/soda/new-documentation.md
@@ -9,6 +9,9 @@ parent: Learning resources
 
 <br />
 
+#### October 28, 2024
+* Add to Soda Agent extras with [instructions]({% link soda-agent/secrets.md %}#use-soda-cloud-api-keys-from-an-existing-secret) on how to use an existing Kubernetes secret for Soda Cloud API keys.
+
 #### October 25, 2024
 * Added [release notes]({% link release-notes/all.md %}) documentation for Soda Library 1.7.1.
 


### PR DESCRIPTION
[CLOUD-8265] Adds existing secret reference for Cloud keys

@janet-can feel free to make changes where needed and merge. 

[CLOUD-8265]: https://sodadata.atlassian.net/browse/CLOUD-8265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ