### PR TITLE
Fix spelling error and change description for "Soda Extras" page

### DIFF
--- a/soda-agent/secrets.md
+++ b/soda-agent/secrets.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Soda Agent extras
-description: Learn how to adjust the Soda Agent to fit your organization's security standards by levering secrets managers, environment variables, and other controls.
+description: Learn how to adjust the Soda Agent to fit your security standards by leveraging secrets managers, environment variables, and other controls.
 parent: Get started
 ---
 

--- a/soda-agent/secrets.md
+++ b/soda-agent/secrets.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Soda Agent extras
-description: Learn how to manage sensitive values using Kubernetes secrets and environment variables, and how to integrate with an extermal secrets manager.
+description: Learn how to adjust the Soda Agent to fit your organization's security standards by levering secrets managers, environment variables, and other controls.
 parent: Get started
 ---
 


### PR DESCRIPTION
Whilst I was at it, I noticed a spelling error, and actually took the opportunity to rewrite the description to reflect the page a bit better. 