### PR TITLE
Fix link on home page to create user group

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@ permalink: /
                 <div>
                     <img src="/assets/images/icons/icon-new@2x.png" width="54" height="40">
                     <h2>What's new?</h2>
-                    <a href="/soda-cloud/roles-global#create-custom-user-groups">Create user groups</a>  
+                    <a href="/soda-cloud/roles-global.html#manage-user-groups">Create user groups</a>  
                     <a href="/soda-cloud/anomaly-dashboard.html">Anomaly detection dashboards</a> 
                     <a href="/soda-cl/anomaly-detection.html">Anomaly detection</a> 
                     <a href="/soda-agent/managed-agent.html">Set up Soda-hosted Agent</a>                                    


### PR DESCRIPTION
* Fixed the wrongly formed url (no `.html` suffix)
* Pointed the link to the correct section