### PR TITLE
Release notes for Soda Library 1.9.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ./vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}

--- a/_release-notes/soda-library-1.9.3.md
+++ b/_release-notes/soda-library-1.9.3.md
@@ -1,0 +1,12 @@
+---
+name: "1.9.3"
+date: 2025-03-14
+products:
+  - soda-library
+---
+
+## 1.9.3 Features and Fixes
+
+* Fix scan time reporting by @mivds in #428
+* Validity check: fix complex mixed rules query (#2219) by @m1n0 in #440
+* fix(trino): handle period character in schema name by @adkinsty in #444

--- a/soda/new-documentation.md
+++ b/soda/new-documentation.md
@@ -9,6 +9,9 @@ parent: Learning resources
 
 <br />
 
+#### March 14, 2025
+ * Added [release notes]({% link release-notes/all.md %}) documentation for Soda Library 1.9.3.
+
 #### February 27, 2025
  * Added [release notes]({% link release-notes/all.md %}) documentation for Soda Agent 1.1.39.
 


### PR DESCRIPTION
* Added release notes for Soda Library 1.9.3
* Also updated .github workflow to use actions/cache v4, since the previous v2 was outdated, causing the deployment to automatically fail.