### PR TITLE
Update docs

### DIFF
--- a/api-docs/openapi_backend_publicapi_v1.yaml
+++ b/api-docs/openapi_backend_publicapi_v1.yaml
@@ -10,6 +10,8 @@ components:
     CheckResultValueDTO:
       type: object
       properties:
+        dataTimestamp:
+          type: string
         diagnostics:
           type: array
           items:
@@ -52,12 +54,15 @@ components:
       properties:
         agreements:
           type: array
+          deprecated: true
           items:
             type: object
             $ref: '#/components/schemas/AgreementSlimDTO'
         attributes:
           type: object
           $ref: '#/components/schemas/MapOfStringToString'
+        checkType:
+          type: string
         cloudUrl:
           type: string
         column:
@@ -91,22 +96,23 @@ components:
           $ref: '#/components/schemas/CheckResultValueDTO'
         lastCheckRunTime:
           type: string
+          deprecated: true
         lastUpdated:
           type: string
+          deprecated: true
         name:
           type: string
         owner:
           type: object
           $ref: '#/components/schemas/OwnerDTO'
+          deprecated: true
       required:
-      - agreements
       - createdAt
       - datasets
       - evaluationStatus
       - id
       - incidents
       - name
-      - owner
     ChecksContentDTO_Group:
       type: object
       properties:
@@ -309,6 +315,8 @@ components:
         id:
           type: string
         name:
+          type: string
+        qualifiedName:
           type: string
     DatasetsContentDTO:
       type: object
@@ -1636,7 +1644,7 @@ paths:
 
         ## Rate limiting
 
-        10 requests/60 seconds
+        100 requests/60 seconds
       operationId: "POST/api/v1/datasets/{datasetId}"
       parameters:
       - in: path


### PR DESCRIPTION
Takes stuff from https://github.com/sodadata/docs/pull/992 and adds additionally [SAS-6484] in to update the throttling rate for the dataset update endpoint

[SAS-6484]: https://sodadata.atlassian.net/browse/SAS-6484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ